### PR TITLE
Use env variable to setup recommender API url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ LSP Server that can analyze your dependencies specified in `package.json`.
 npm install
 npm run-script build
 ```
+## Setup
+we use 2 environment variables to setup the recommender API
+```
+export RECOMMENDER_API_URL=https://recommender.api.openshift.io/api/v1
+export RECOMMENDER_API_TOKEN=the-token
+
+```
 
 ## License
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -173,7 +173,7 @@ class AnalysisConfig
 
     constructor() {
         // TODO: this needs to be configurable
-        this.server_url = 'https://recommender.api.openshift.io/api/v1';
+        this.server_url = process.env.RECOMMENDER_API_URL || "api-url-not-available-in-lsp";
         this.api_token = process.env.RECOMMENDER_API_TOKEN || "token-not-available-in-lsp";
         this.forbidden_licenses = [];
         this.no_crypto = false;


### PR DESCRIPTION
Use environment variable to configure recommender API url
Fix #1 