### PR TITLE
Log in folder /home/user/che/ls-bayesian

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ const request = require('request');
 const winston = require('winston');
 
  winston.level = 'debug';
- winston.add(winston.transports.File, { filename: 'bayesian.log' });
+ winston.add(winston.transports.File, { filename: '/home/user/che/ls-bayesian/bayesian.log' });
  winston.remove(winston.transports.Console);
  winston.info('Starting Bayesian');
 


### PR DESCRIPTION
Currently bayesian.log is created in current working directory (i.e. `/projects/` for Che workspaces). 

For consistency with other workspace agents ls-bayesian should log in it's own directory (`/home/user/che`).