### PR TITLE
WIP: Sentiment Analysis with lsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     },
     "scripts": {
         "build": "node node_modules/typescript/bin/tsc -p .",
-        "dist": "cp -r node_modules/ output/ && node -p -e \"require('./package.json').version\" > output/VERSION && rm -rf output/node_modules/typescript/ && tar cvjf ca-lsp-server.tar -C output/ ."
+        "dist": "cp -r node_modules output/ && node -p -e \"require('./package.json').version\" > output/VERSION && rm -rf output/node_modules/typescript/ && tar cvjf ca-lsp-server.tar -C output/ ."
     }
 }

--- a/src/sentiment.ts
+++ b/src/sentiment.ts
@@ -1,0 +1,163 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Pavel Odvody 2016
+ * Licensed under the Apache-2.0 License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+import { IDependency } from './collector';
+import { get_range } from './utils';
+import { Diagnostic, DiagnosticSeverity, Command } from 'vscode-languageserver'
+
+/* Descriptor describing what key-path to extract from the document */
+interface IBindingDescriptor
+{
+    path: Array<string>;
+};
+
+/* Bind & return the part of `obj` as described by `desc` */
+let bind_object = (obj: any, desc: IBindingDescriptor) => {
+    let bind = obj;
+    for (let elem of desc.path) {
+        if (elem in bind) {
+            bind = bind[elem];
+        } else {
+            return null;
+        }
+    }
+    return bind;
+};
+
+/* Arbitrary metadata consumer interface */
+interface IConsumer
+{
+    binding: IBindingDescriptor;
+    item: any;
+    consume(data: any): boolean;
+};
+
+/* Generic `T` producer */
+interface IProducer<T>
+{
+    produce(): T;
+};
+
+/* Each pipeline item is defined as a single consumer and producer pair */
+interface IPipelineItem<T> extends IConsumer, IProducer<T> {}; 
+
+/* House bunches of `IPipelineItem`'s */
+interface IPipeline<T>
+{
+    items: Array<IPipelineItem<T>>;
+    run(data: any): T;
+};
+
+/* Diagnostics producer type */
+type DiagnosticProducer = IProducer<Diagnostic[]>;
+
+/* Diagnostics pipeline implementation */
+class DiagnosticsPipelineSenti implements IPipeline<Diagnostic[]>
+{
+    items: Array<IPipelineItem<Diagnostic[]>>;
+    dependency: IDependency;
+    config: any;
+    diagnostics: Array<Diagnostic>;
+    constructor(classes: Array<any>, dependency: IDependency, config: any, diags: Array<Diagnostic>) {
+        this.items = classes.map((i) => { return new i(dependency, config); });
+        this.dependency = dependency;
+        this.config = config;
+        this.diagnostics = diags;
+    }
+
+    run(data: any): Diagnostic[] {
+        for (let item of this.items) {
+            if (item.consume(data)) {
+                for (let d of item.produce())
+                    this.diagnostics.push(d);
+            }
+        }
+        return this.diagnostics;
+    }
+};
+
+/* A consumer that uses the binding interface to consume a metadata object */
+class AnalysisConsumer implements IConsumer
+{
+    binding: IBindingDescriptor;
+    changeToBinding: IBindingDescriptor;
+    item: any;
+    changeTo: string = null;
+    constructor(public config: any){}
+    consume(data: any): boolean {
+        // if (this.binding != null) {
+        //     this.item = bind_object(data, this.binding);
+        // } else {
+            if(data && data.sentiment_details && data.sentiment_details.hasOwnProperty("overall_sentiment_score"))
+            {
+            this.item = [];
+            this.item.push(data.sentiment_details.overall_sentiment_score);
+            }
+        // }
+        // if (this.changeToBinding != null) {
+        //     this.changeTo = bind_object(data, this.changeToBinding);
+        // }
+        return this.item != null;
+    }
+};
+
+/* We've received an empty/unfinished result, display that analysis is pending */
+class EmptyResultEngineSenti extends AnalysisConsumer implements DiagnosticProducer
+{
+    constructor(public context: IDependency, config: any) {
+        super(config);
+    }
+
+    produce(): Diagnostic[] {
+        if (this.item == {} || 
+            this.item.finished_at === undefined ||
+            this.item.finished_at == null) {
+            return [{
+                severity: DiagnosticSeverity.Information,
+                range: get_range(this.context.version),
+                message: `Package ${this.context.name.value}-${this.context.version.value} - analysis is pending`,
+                source: 'Component Analysis'
+            }]
+        } else {
+            return [];
+        }
+    }   
+}
+
+/* Report CVEs in found dependencies */
+class SecurityEngineSenti extends AnalysisConsumer implements DiagnosticProducer
+{
+    constructor(public context: IDependency, config: any) {
+        super(config);
+        this.binding = {path: ['result', 'recommendation', 'component-analyses', 'cve']};
+        /* recommendation to use a different version */
+        this.changeToBinding = {path: ['result', 'recommendation', 'change_to']};
+    }
+
+    produce(): Diagnostic[] {
+        if (this.item.length > 0) {
+            let scoreList = [];
+            for (let score of this.item) {
+                scoreList.push(score)
+            }
+            let cves = scoreList.join(' ');
+
+            let diagnostic = {
+                severity: DiagnosticSeverity.Error,
+                range: get_range(this.context.version),
+                message: `Package ${this.context.name.value}-${this.context.version.value} is having sentiment score of: ${cves}`,
+                source: 'Sentiment Analysis'
+            };
+
+            return [diagnostic]
+        } else {
+            return [];
+        }
+    }
+};
+
+let codeActionsMapSenti = new Map<string, Command>();
+
+export { DiagnosticsPipelineSenti, SecurityEngineSenti, EmptyResultEngineSenti, codeActionsMapSenti };

--- a/src/sentiment.ts
+++ b/src/sentiment.ts
@@ -90,10 +90,10 @@ class AnalysisConsumer implements IConsumer
         // if (this.binding != null) {
         //     this.item = bind_object(data, this.binding);
         // } else {
-            if(data && data.sentiment_details && data.sentiment_details.hasOwnProperty("overall_sentiment_score"))
+            if(data && data.sentiment_details && data.sentiment_details.hasOwnProperty("latest_comment") && data.sentiment_details.latest_comment != '')
             {
             this.item = [];
-            this.item.push(data.sentiment_details.overall_sentiment_score);
+            this.item.push(data.sentiment_details.latest_comment);
             }
         // }
         // if (this.changeToBinding != null) {
@@ -145,9 +145,9 @@ class SecurityEngineSenti extends AnalysisConsumer implements DiagnosticProducer
             let cves = scoreList.join(' ');
 
             let diagnostic = {
-                severity: DiagnosticSeverity.Error,
+                severity: DiagnosticSeverity.Information,
                 range: get_range(this.context.version),
-                message: `Package ${this.context.name.value}-${this.context.version.value} is having sentiment score of: ${cves}`,
+                message: `Package ${this.context.name.value}-${this.context.version.value} is having latest comment as: ${cves}`,
                 source: 'Sentiment Analysis'
             };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -308,6 +308,14 @@ files.on(EventStream.Diagnostics, "^pom\\.xml$", (uri, name, contents) => {
                 }
                 aggregator.aggregate(dependency);
             });
+
+            sentiment_api_call('maven', dependency.name.value, dependency.version.value, (response) => {
+                if (response != null) {
+                    let pipeline = new DiagnosticsPipelineSenti(DiagnosticsEnginesSenti, dependency, config, diagnostics);
+                    pipeline.run(response);
+                }
+                aggregator.aggregate(dependency);
+            });
         }
     });
 });


### PR DESCRIPTION
- integrates sentiment analysis call (consuming it from dev cluster currently , need to make changes on api moves to prod)
- pass diagnostic object to che client for sentiments which have latest comment along with score , categorised as Positive, Negative and Neutral