### PR TITLE
Use a path that is storing on a persistent volume

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -19,7 +19,7 @@ const request = require('request');
 const winston = require('winston');
 
  winston.level = 'debug';
- winston.add(winston.transports.File, { filename: '/home/user/che/ls-bayesian/bayesian.log' });
+ winston.add(winston.transports.File, { filename: '/workspace-logs/ls-bayesian/bayesian.log' });
  winston.remove(winston.transports.Console);
  winston.info('Starting Bayesian');
 


### PR DESCRIPTION
For now, it logs in /home/user/che but as part of logging to a persistent volume, we may log to the `/workspace-logs` folder which is backed by the persistent volume.

warning : it requires merged PR https://github.com/redhat-developer/rh-che/pull/199

https://github.com/redhat-developer/rh-che/issues/145

@l0rd 