### PR TITLE
#16 add a pom wrapper so we can use the...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,7 @@ jspm_packages
 
 # Others
 .idea/
-ca-lsp-server.tar
 output/
+
+# generated tarball and publishing scripts
+target/

--- a/make-tarball.sh
+++ b/make-tarball.sh
@@ -1,7 +1,30 @@
 #!/bin/bash -ex
 
-rm -Rf ca-lsp-server.tar output/
+rm -Rf target/ output/
 npm install
 npm run-script build
 npm run dist
 
+gzip ca-lsp-server.tar
+
+# rename the tar.gz to the version in the pom so it's easier to deploy it 
+if [[ $1 ]]; then mv ca-lsp-server{,-${1}}.tar.gz; fi
+
+# move the gz into a target/ folder
+mkdir -p target && mv *lsp-server*.tar* target/
+
+# to publish the generated tarball, pass in params:
+# eg., $0 0.0.6-SNAPSHOT USER@SERVER:BASE/PATH 99
+if [[ $2 ]]; then
+	DESTINATION=$2 # set this to where you want to rsync the files, eg., USER@SERVER:BASE/PATH 
+	SOURCEDIR=`pwd`/target
+	BUILD_TIMESTAMP=`date -u +%Y-%m-%d_%H-%M-%S`
+	if [[ $3 ]]; then BUILD_NUMBER="$3"; else BUILD_NUMBER=00; fi
+	for f in publish/rsync.sh util/cleanup/jbosstools-cleanup.sh; do
+	  curl -s -S -k --create-dirs -o ${SOURCEDIR}/${f} https://raw.githubusercontent.com/jbosstools/jbosstools-build-ci/master/${f} && \
+	  chmod +x ${SOURCEDIR}/${f}
+	done
+	${SOURCEDIR}/publish/rsync.sh -s ${SOURCEDIR} -i *lsp-server*.tar* \
+	  -DESTINATION ${DESTINATION} -k 4 -l 0 -a 4 --no-regen-metadata -BUILD_NUMBER ${BUILD_NUMBER} \
+	  -t oxygen/snapshots/builds/jbosstools-fabric8analytics-lsp-server_master/${BUILD_TIMESTAMP}-B${BUILD_NUMBER}/
+fi


### PR DESCRIPTION
#16 add a pom wrapper so we can use the JBoss Tools parent pom and deployment mechanism to push the built tar.gz to download.jboss.org

Signed-off-by: nickboldt <nboldt@redhat.com>