### PR TITLE
fix(pr-merge-build): ignoring semantic-release post command for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "scripts": {
     "build": "node node_modules/typescript/bin/tsc -p .",
     "dist": "cp -r node_modules output/ && cp ./package.json output/ && node -p -e \"require('./package.json').version\" > output/VERSION && rm -rf output/node_modules/typescript/ && tar cvjf ca-lsp-server.tar -C output/ .",
-    "semantic-release": "semantic-release pre && npm run build && cp -r .git output && npm publish output/ && semantic-release post"
+    "semantic-release": "semantic-release pre && npm run build && cp -r .git output && npm publish output/"
   }
 }


### PR DESCRIPTION
- removed `semantic-release post` command as this will be a modified as per the requirement to include the .tar file.