### PR TITLE
fix(pypi): Dependency count shown in stack analysis report is incorrect

### DIFF
--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -7,3 +7,5 @@ set -ex
 install_dependencies
 
 build_project
+
+run_unit_tests

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -51,6 +51,19 @@ build_project() {
   fi
 }
 
+run_unit_tests() {
+    # Exec unit tests
+    npm test
+
+    if [ $? -eq 0 ]; then
+        echo 'CICO: unit tests OK'
+    else
+        echo 'CICO: unit tests FAIL'
+        exit 2
+    fi
+}
+
+
 . cico_release.sh
 
 load_jenkins_vars

--- a/package.json
+++ b/package.json
@@ -37,16 +37,40 @@
     "xml2object": "0.1.2"
   },
   "devDependencies": {
-    "@types/node": "^6.0.52",
     "@krux/condition-jenkins": "1.0.1",
+    "@types/chai": "^4.1.7",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^6.0.52",
+    "chai": "^4.2.0",
+    "mocha": "^6.2.0",
+    "nyc": "^14.1.1",
     "semantic-release": "8.2.0",
-    "typescript": "^2.1.4"
+    "ts-node": "^8.3.0",
+    "typescript": "^2.9.2"
   },
   "scripts": {
     "build": "npm run clean && node node_modules/typescript/bin/tsc -p . && cp LICENSE package.json README.md output && npm run dist",
     "clean": "rm -Rf ca-lsp-server.tar output/",
+    "test": "nyc mocha",
     "dist": "cp -r node_modules output/ && cp ./package.json output/ && node -p -e \"require('./package.json').version\" > output/VERSION && rm -rf output/node_modules/typescript/ && tar cvjf ca-lsp-server.tar -C output/ .",
     "semantic-release": "semantic-release pre && npm run build && cp -r .git output && npm publish output/ && semantic-release post"
+  },
+  "nyc": {
+    "include": [
+      "src/**/*.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "text",
+      "html"
+    ],
+    "sourceMap": true,
+    "instrument": true
   },
   "release": {
     "branch": "master",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--require ts-node/register
+--full-trace
+--bail
+test/**/*.test.ts

--- a/test/pypi.collector.test.ts
+++ b/test/pypi.collector.test.ts
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+import { ReqDependencyCollector } from '../src/collector';
+
+describe('PyPi requirements.txt parser test', () => {
+    const collector:ReqDependencyCollector = new ReqDependencyCollector();
+
+    it('tests valid requirements.txt', async () => {
+        const deps = await collector.collect(`a==1
+            b==2.1.1
+            c>=10.1
+            d<=20.1.2.3.4.5.6.7.8
+        `);
+        expect(deps.length).equal(4);
+        expect(deps[0]).is.eql({
+          name: {value: 'a', position: {line: 0, column: 0}},
+          version: {value: '1', position: {line: 1, column: 4}}
+        });
+        expect(deps[1]).is.eql({
+          name: {value: 'b', position: {line: 0, column: 0}},
+          version: {value: '2.1.1', position: {line: 2, column: 16}}
+        });
+        expect(deps[2]).is.eql({
+          name: {value: 'c', position: {line: 0, column: 0}},
+          version: {value: '10.1', position: {line: 3, column: 16}}
+        });
+        expect(deps[3]).is.eql({
+          name: {value: 'd', position: {line: 0, column: 0}},
+          version: {value: '20.1.2.3.4.5.6.7.8', position: {line: 4, column: 16}}
+        });
+    });
+
+    it('tests requirements.txt with comments', async () => {
+        const deps = await collector.collect(`# hello world
+            a==1 # hello
+            # another comment b==2.1.1
+            c # yet another comment >=10.1
+            d<=20.1.2.3.4.5.6.7.8
+            # done
+        `);
+        expect(deps.length).equal(3);
+        expect(deps[0]).is.eql({
+          name: {value: 'a', position: {line: 0, column: 0}},
+          version: {value: '1', position: {line: 2, column: 16}}
+        });
+        expect(deps[1]).is.eql({
+          name: {value: 'c', position: {line: 0, column: 0}},
+          version: {value: '', position: {line: 4, column: 1}} // column shouldn't matter for empty versions
+        });
+        expect(deps[2]).is.eql({
+          name: {value: 'd', position: {line: 0, column: 0}},
+          version: {value: '20.1.2.3.4.5.6.7.8', position: {line: 5, column: 16}}
+        });
+    });
+
+    it('tests empty lines', async () => {
+        const deps = await collector.collect(`
+
+            a==1
+
+        `);
+        expect(deps.length).equal(1);
+        expect(deps[0]).is.eql({
+          name: {value: 'a', position: {line: 0, column: 0}},
+          version: {value: '1', position: {line: 3, column: 16}}
+        });
+    });
+
+    it('tests deps with spaces before and after comparators', async () => {
+        const deps = await collector.collect(`
+            a        ==1               
+
+                  b        <=     10.1               
+
+        `);
+        expect(deps.length).equal(2);
+        expect(deps[0]).is.eql({
+          name: {value: 'a', position: {line: 0, column: 0}},
+          version: {value: '1', position: {line: 2, column: 24}}
+        });
+        expect(deps[1]).is.eql({
+          name: {value: 'b', position: {line: 0, column: 0}},
+          version: {value: '10.1', position: {line: 4, column: 35}}
+        });
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
-	"compilerOptions": {
-		"target": "ES6",
-		"module": "commonjs",
-		"moduleResolution": "node",
-		"sourceMap": true,
-		"outDir": "output"
-	},
-	"exclude": [
-		"node_modules"
-	]
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "output"
+  },
+  "exclude": [
+    "node_modules",
+    "test"
+  ]
 }


### PR DESCRIPTION
It fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/315.

### Root cause:
Empty lines(with and without #) are also counted as dependencies.

### Solution:
If parsed package name is empty, ignore it.

### Cleanup:
I also did some refactoring to use JS map/reduce for a nice looking code :)

### Testing:
Chai, mocha based unit tests has been added newly. Also added [nyc](https://istanbul.js.org/) based code coverage and modified code has been covered 100%.

Follow the below steps to test this change along with fabric8-analytics-vscode-extension,

```
git clone https://github.com/fabric8-analytics/fabric8-analytics-lsp-server.git
cd fabric8-analytics-lsp-server
git fetch https://github.com/arajkumar/fabric8-analytics-lsp-server.git fix-incorrect-dep-count-pypi
git checkout FETCH_HEAD
npm install && npm run build

git clone https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension.git
cd fabric8-analytics-vscode-extension
git fetch https://github.com/invincibleJai/fabric8-analytics-vscode-extension fix-py-sup-ls
git checkout FETCH_HEAD
npm install /path/to/fabric8-analytics-lsp-server/output

# Then launch VS code & debug
```

<img width="1522" alt="Screen Shot 2019-07-30 at 4 24 56 PM" src="https://user-images.githubusercontent.com/3874763/62124058-e8d4e780-b2e6-11e9-8565-78dd6fbd2fc3.png">
