### PR TITLE
fix(uri-char): URI encode the args which is passed for component anaysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "request": "^2.79.0",
-    "stream-json": "1.3.1",
+    "stream-json": "0.6.1",
     "winston": "3.2.1",
     "xml2object": "0.1.2",
     "vscode-languageserver": "^5.3.0-next.9"

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -5,6 +5,7 @@
 'use strict';
 import { StreamingParser, IPosition, IKeyValueEntry, KeyValueEntry, Variant, ValueType } from './json';
 import * as Xml2Object from 'xml2object';
+import { stream_from_string } from './utils';
 import { Stream } from 'stream';
 
 /* By default the collector is going to process these dependency keys */
@@ -25,7 +26,7 @@ interface IDependency {
 /* Dependency collector interface */
 interface IDependencyCollector {
   classes: Array<string>;
-  collect(file: Stream): Promise<Array<IDependency>>;
+  collect(contents: string): Promise<Array<IDependency>>;
 }
 
 /* Dependency class that can be created from `IKeyValueEntry` */
@@ -51,7 +52,8 @@ class DependencyCollector implements IDependencyCollector {
         this.classes = classes || DefaultClasses
     }
 
-    async collect(file: Stream): Promise<Array<IDependency>> {
+    async collect(contents: string): Promise<Array<IDependency>> {
+        const file = stream_from_string(contents);
         let parser = new StreamingParser(file);
         let dependencies: Array<IDependency> = [];
         let tree = await parser.parse();
@@ -187,7 +189,8 @@ class NaivePomXmlSaxParser {
 class PomXmlDependencyCollector {
     constructor(public classes: Array<string> = ["dependencies"]) {}
 
-    async collect(file: Stream): Promise<Array<IDependency>> {
+    async collect(contents: string): Promise<Array<IDependency>> {
+        const file = stream_from_string(contents);
         let parser = new NaivePomXmlSaxParser(file);
         let dependencies;
          await parser.parse().then(data => {

--- a/src/json.ts
+++ b/src/json.ts
@@ -6,8 +6,10 @@
 import { Stream } from 'stream';
 /* Since the following modules are written in regular JS we can't use TS's import statement
    so we need to `require` those the JS way */
-import { Parser, Streamer, Emitter, Packer } from 'stream-json';
-
+import * as Parser from 'stream-json/ClassicParser';
+import * as Streamer from 'stream-json/Streamer';
+import * as Emitter from 'stream-json/Emitter';
+import * as Packer from 'stream-json/Packer';
 /* Determine to which class the emitted token belongs */
 enum TokenMarker {
   Invalid,

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,8 +9,8 @@ import {
 	IPCMessageReader, IPCMessageWriter, createConnection, IConnection,
 	TextDocuments, Diagnostic, InitializeResult, CodeLens, CodeAction, RequestHandler, CodeActionParams
 } from 'vscode-languageserver';
-import { stream_from_string } from './utils';
-import { DependencyCollector, IDependency, PomXmlDependencyCollector, ReqDependencyCollector } from './collector';
+import { Stream } from 'stream';
+import { DependencyCollector, IDependency, IDependencyCollector, PomXmlDependencyCollector, ReqDependencyCollector } from './collector';
 import { EmptyResultEngine, SecurityEngine, DiagnosticsPipeline, codeActionsMap } from './consumers';
 
 const url = require('url');
@@ -207,8 +207,8 @@ const getCAmsg = (deps, diagnostics): string => {
 
 const caDefaultMsg = 'Checking for security vulnerabilities ...';
 
-let metadataCache = new Map();
-let get_metadata = (ecosystem, name, version) => {
+const metadataCache = new Map();
+const get_metadata = (ecosystem, name, version) => {
     return new Promise((resolve, reject) => {
         let cacheKey = ecosystem + " " + name + " " + version;
         let metadata = metadataCache[cacheKey];
@@ -240,12 +240,6 @@ let get_metadata = (ecosystem, name, version) => {
                             logger.debug('response ' + response);
                             metadataCache[cacheKey] = response;
                             resolve(response);
-                        } else if(httpResponse.statusCode === 401){
-                            reject(httpResponse.statusCode);
-                        } else if(httpResponse.statusCode === 429 || httpResponse.statusCode === 403){
-                            reject(httpResponse.statusCode);
-                        } else if(httpResponse.statusCode === 400){
-                            reject(httpResponse.statusCode);
                         } else {
                             reject(httpResponse.statusCode);
                         }
@@ -256,75 +250,8 @@ let get_metadata = (ecosystem, name, version) => {
     });
 };
 
-
-files.on(EventStream.Diagnostics, "^package\\.json$", (uri, name, contents) => {
-    /* Convert from readable stream into string */
-    let stream = stream_from_string(contents);
-    let collector = new DependencyCollector(null);
+const sendDiagnostics = (ecosystem: string, uri: string, contents: string, collector: IDependencyCollector) => {
     connection.sendNotification('caNotification', {'data': caDefaultMsg});
-
-    collector.collect(stream).then((deps) => {
-        let diagnostics = [];
-        /* Aggregate asynchronous requests and send the diagnostics at once */
-        let aggregator = new Aggregator(deps, () => {
-            connection.sendNotification('caNotification', {'data': getCAmsg(deps, diagnostics), 'diagCount' : diagnostics.length > 0? diagnostics.length : 0});
-            connection.sendDiagnostics({uri: uri, diagnostics: diagnostics});
-        });
-        const regexVersion =  new RegExp(/^([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+)$/);
-        for (let dependency of deps) {
-            if(dependency.name.value && dependency.version.value && regexVersion.test(dependency.version.value)) {
-                get_metadata('npm', dependency.name.value, dependency.version.value).then((response) => {
-                    if (response != null) {
-                        let pipeline = new DiagnosticsPipeline(DiagnosticsEngines, dependency, config, diagnostics, uri);
-                        pipeline.run(response);
-                    }
-                    aggregator.aggregate(dependency);
-                }).catch((err)=>{
-                    connection.console.log(err);
-                });
-            } else {
-                aggregator.aggregate(dependency);
-            }
-        }
-    });
-});
-
-files.on(EventStream.Diagnostics, "^pom\\.xml$", (uri, name, contents) => {
-    /* Convert from readable stream into string */
-    let stream = stream_from_string(contents);
-    let collector = new PomXmlDependencyCollector();
-    connection.sendNotification('caNotification', {'data': caDefaultMsg});
-
-    collector.collect(stream).then((deps) => {
-        let diagnostics = [];
-        /* Aggregate asynchronous requests and send the diagnostics at once */
-        let aggregator = new Aggregator(deps, () => {
-            connection.sendNotification('caNotification', {'data': getCAmsg(deps, diagnostics), 'diagCount' : diagnostics.length > 0? diagnostics.length : 0});
-            connection.sendDiagnostics({uri: uri, diagnostics: diagnostics});
-        });
-        const regexVersion =  new RegExp(/^([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+)$/);
-        for (let dependency of deps) {
-            if(dependency.name.value && dependency.version.value && regexVersion.test(dependency.version.value)) {
-                get_metadata('maven', dependency.name.value, dependency.version.value).then((response) => {
-                    if (response != null) {
-                        let pipeline = new DiagnosticsPipeline(DiagnosticsEngines, dependency, config, diagnostics, uri);
-                        pipeline.run(response);
-                    }
-                    aggregator.aggregate(dependency);
-                }).catch((err)=>{
-                    connection.console.log(err);
-                });
-            } else {
-                aggregator.aggregate(dependency);
-            }
-        }
-    });
-});
-
-files.on(EventStream.Diagnostics, "^requirements\\.txt$", (uri, name, contents) => {
-    let collector = new ReqDependencyCollector();
-    connection.sendNotification('caNotification', {'data': caDefaultMsg});
-
     collector.collect(contents).then((deps) => {
         let diagnostics = [];
         /* Aggregate asynchronous requests and send the diagnostics at once */
@@ -334,9 +261,8 @@ files.on(EventStream.Diagnostics, "^requirements\\.txt$", (uri, name, contents) 
         });
         const regexVersion =  new RegExp(/^([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+)$/);
         for (let dependency of deps) {
-            logger.info('python cmp name'+ dependency.name.value);
             if(dependency.name.value && dependency.version.value && regexVersion.test(dependency.version.value.trim())) {
-                get_metadata('pypi', dependency.name.value, dependency.version.value).then((response) => {
+                get_metadata(ecosystem, dependency.name.value, dependency.version.value).then((response) => {
                     if (response != null) {
                         let pipeline = new DiagnosticsPipeline(DiagnosticsEngines, dependency, config, diagnostics, uri);
                         pipeline.run(response);
@@ -350,6 +276,19 @@ files.on(EventStream.Diagnostics, "^requirements\\.txt$", (uri, name, contents) 
             }
         }
     });
+};
+
+files.on(EventStream.Diagnostics, "^package\\.json$", (uri, name, contents) => {
+    sendDiagnostics('npm', uri, contents, new DependencyCollector(null));
+});
+
+files.on(EventStream.Diagnostics, "^pom\\.xml$", (uri, name, contents) => {
+    sendDiagnostics('maven', uri, contents, new PomXmlDependencyCollector());
+});
+
+
+files.on(EventStream.Diagnostics, "^requirements\\.txt$", (uri, name, contents) => {
+    sendDiagnostics('pypi', uri, contents, new ReqDependencyCollector());
 });
 
 let checkDelay;


### PR DESCRIPTION
fix(stream-json): Move to 0.x, new release doesn't pass position info
Refactor send diag message to avoid duplicate codes

Issue: https://jira.coreos.com/browse/APPAI-1060

### Root cause:

https://gist.github.com/samuzzal-choudhury/618a50bba5f3c1f829d6abe8dc6057ed

There are few dependencies are in the form of `mainpkg/subpkg` in the above manifest file(e.g. `@angular/animations`),  which causes `subpkg` being interpreted as version. 

### Solution:

URI encoding the dependency name.

### LSP notification with fix:
<img width="1792" alt="Screenshot 2019-11-12 at 7 58 00 PM" src="https://user-images.githubusercontent.com/3874763/68680239-5ac7f880-0587-11ea-8ce7-9d059e89c039.png">
