### PR TITLE
fix(pr): Don't create PR to upgrade lsp in vscode extension repo

### DIFF
--- a/cico_release.sh
+++ b/cico_release.sh
@@ -23,7 +23,7 @@ function release() {
 
     publish_tar
 
-    create_merge_PR_vscode
+    # create_merge_PR_vscode
 
     # create_PR_RHChe
 }


### PR DESCRIPTION
Skipping this until PR creation stabilises.