### PR TITLE
fix: Strip remote name from GIT_BRANCH env var

### DIFF
--- a/cico_release.sh
+++ b/cico_release.sh
@@ -19,5 +19,6 @@ function release() {
     npm config set loglevel verbose
 
     # Build and Release fabric8-analytics-lsp-server (It will update the tag on github and push fabric8-analytics-lsp-server to npmjs.org)
-    CI=true npm run semantic-release
+    # From GIT_BRANCH remove origin/ to make semantic-release happy.
+    GIT_BRANCH="${GIT_BRANCH//origin\//}" npm run semantic-release
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript": "^3.6.3"
   },
   "scripts": {
-    "build": "tsc -p .",
+    "build": "tsc -p . && cp package.json output",
     "test": "nyc mocha",
     "semantic-release": "semantic-release --debug"
   },
@@ -77,7 +77,7 @@
       [
         "@semantic-release/exec",
         {
-          "verifyConditionsCmd": "npm run build && cp package.json package-lock.json output",
+          "verifyConditionsCmd": "npm run build && cp package-lock.json output",
           "publishCmd": "cd output && npm i --only=prod && echo ${nextRelease.version}>VERSION && tar cvjf ../ca-lsp-server.tar ."
         }
       ],

--- a/package.json
+++ b/package.json
@@ -71,10 +71,6 @@
     "instrument": true
   },
   "release": {
-    "branches": [
-      "origin/master"
-    ],
-    "debug": true,
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
@@ -89,7 +85,9 @@
         "@semantic-release/github",
         {
           "assets": [
-            {"path": "ca-lsp-server.tar"}
+            {
+              "path": "ca-lsp-server.tar"
+            }
           ]
         }
       ],


### PR DESCRIPTION
This fixes the below error,

[semantic-release] › ℹ  This test run was triggered on the branch origin/master, while semantic-release is configured to only publish from master, therefore a new version won’t be published.