### PR TITLE
fix: Support for single line require and version string parsing using regex

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -8,7 +8,12 @@ import * as Xml2Object from 'xml2object';
 import { stream_from_string } from './utils';
 import { Stream } from 'stream';
 
-import semverRegex = require('semver-regex');
+/* Please note :: There was issue with semverRegex usage in the code. During run time, it extracts 
+ * version with 'v' prefix, but this is not be behavior of semver in CLI and test environment. 
+ * At the moment, using regex directly to extract version information without 'v' prefix. */
+//import semverRegex = require('semver-regex');
+const regExp = /(?<=^v?|\sv?)(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*)(?:\.(?:0|[1-9]\d*|[\da-z-]*[a-z-][\da-z-]*))*)?(?:\+[\da-z-]+(?:\.[\da-z-]+)*)?(?=$|\s)/ig
+                
 
 /* By default the collector is going to process these dependency keys */
 const DefaultClasses = ["dependencies"];
@@ -136,16 +141,19 @@ class NaiveGomodParser {
                 if (line.includes("//")) {
                     line = line.split("//")[0];
                 }
-                const version = semverRegex().exec(line)
-                // Skip lines without version string
+                // Not using semver directly, look at comment on import statement.
+                //const version = semverRegex().exec(line)
+                regExp.lastIndex = 0;
+                const version = regExp.exec(line);
+      	        // Skip lines without version string
                 if (version && version.length > 0) {
-                    const parts: Array<string>  = line.trim().split(' ');
+                    const parts: Array<string>  = line.replace('require', '').replace('(', '').replace(')', '').trim().split(' ');
                     const pkgName:string = (parts[0] || '').trim();
                     // Ignore line starting with replace clause and empty package
                     if (pkgName.length > 0) {
                         const entry: IKeyValueEntry = new KeyValueEntry(pkgName, { line: 0, column: 0 });
-                        entry.value = new Variant(ValueType.String, version[0]);
-                        entry.value_position = { line: index + 1, column: version.index + 1 };
+                        entry.value = new Variant(ValueType.String, 'v' + version[0]);
+                        entry.value_position = { line: index + 1, column: version.index };
                         dependencies.push(new Dependency(entry));
                     }
                 }

--- a/test/gomod.collector.test.ts
+++ b/test/gomod.collector.test.ts
@@ -18,19 +18,19 @@ describe('Golang go.mod parser test', () => {
         expect(deps.length).equal(4);
         expect(deps[0]).is.eql({
           name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
-          version: {value: '0.0.0-20151022065526-2efee857e7cf', position: {line: 4, column: 42}},
+          version: {value: 'v0.0.0-20151022065526-2efee857e7cf', position: {line: 4, column: 41}},
         });
         expect(deps[1]).is.eql({
           name: {value: 'github.com/davecgh/go-spew', position: {line: 0, column: 0}},
-          version: {value: '1.1.1', position: {line: 5, column: 41}},
+          version: {value: 'v1.1.1', position: {line: 5, column: 40}},
         });
         expect(deps[2]).is.eql({
           name: {value: 'github.com/pmezard/go-difflib', position: {line: 0, column: 0}},
-          version: {value: '1.0.0', position: {line: 6, column: 44}},
+          version: {value: 'v1.0.0', position: {line: 6, column: 43}},
         });
         expect(deps[3]).is.eql({
           name: {value: 'github.com/stretchr/testify', position: {line: 0, column: 0}},
-          version: {value: '1.2.2', position: {line: 7, column: 42}},
+          version: {value: 'v1.2.2', position: {line: 7, column: 41}},
         });
     });
 
@@ -49,15 +49,15 @@ describe('Golang go.mod parser test', () => {
         expect(deps.length).equal(3);
         expect(deps[0]).is.eql({
           name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
-          version: {value: '0.0.0-20151022065526-2efee857e7cf', position: {line: 4, column: 42}},
+          version: {value: 'v0.0.0-20151022065526-2efee857e7cf', position: {line: 4, column: 41}},
         });
         expect(deps[1]).is.eql({
           name: {value: 'github.com/pmezard/go-difflib', position: {line: 0, column: 0}},
-          version: {value: '1.0.0', position: {line: 6, column: 44}},
+          version: {value: 'v1.0.0', position: {line: 6, column: 43}},
         });
         expect(deps[2]).is.eql({
           name: {value: 'github.com/stretchr/testify', position: {line: 0, column: 0}},
-          version: {value: '1.2.2', position: {line: 7, column: 42}},
+          version: {value: 'v1.2.2', position: {line: 7, column: 41}},
         });
     });
 
@@ -78,11 +78,11 @@ describe('Golang go.mod parser test', () => {
         expect(deps.length).equal(2);
         expect(deps[0]).is.eql({
           name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
-          version: {value: '0.0.0-20151022065526-2efee857e7cf', position: {line: 6, column: 42}},
+          version: {value: 'v0.0.0-20151022065526-2efee857e7cf', position: {line: 6, column: 41}},
         });
         expect(deps[1]).is.eql({
           name: {value: 'github.com/stretchr/testify', position: {line: 0, column: 0}},
-          version: {value: '1.2.2', position: {line: 8, column: 42}},
+          version: {value: 'v1.2.2', position: {line: 8, column: 41}},
         });
     });
 
@@ -92,27 +92,27 @@ describe('Golang go.mod parser test', () => {
           require (
             github.com/alecthomas/units    v0.0.0-20151022065526-2efee857e7cf
                 github.com/davecgh/go-spew      v1.1.1 // indirect
-              github.com/pmezard/go-difflib       v1.0.0    // indirect
-             github.com/stretchr/testify    v1.2.2
+		github.com/pmezard/go-difflib       v1.0.0    // indirect
+	    github.com/stretchr/testify    v1.2.2
           )
           go 1.13
         `);
         expect(deps.length).equal(4);
         expect(deps[0]).is.eql({
           name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
-          version: {value: '0.0.0-20151022065526-2efee857e7cf', position: {line: 4, column: 45}},
+          version: {value: 'v0.0.0-20151022065526-2efee857e7cf', position: {line: 4, column: 44}},
         });
         expect(deps[1]).is.eql({
           name: {value: 'github.com/davecgh/go-spew', position: {line: 0, column: 0}},
-          version: {value: '1.1.1', position: {line: 5, column: 50}},
+          version: {value: 'v1.1.1', position: {line: 5, column: 49}},
         });
         expect(deps[2]).is.eql({
           name: {value: 'github.com/pmezard/go-difflib', position: {line: 0, column: 0}},
-          version: {value: '1.0.0', position: {line: 6, column: 52}},
+          version: {value: 'v1.0.0', position: {line: 6, column: 39}},
         });
         expect(deps[3]).is.eql({
           name: {value: 'github.com/stretchr/testify', position: {line: 0, column: 0}},
-          version: {value: '1.2.2', position: {line: 7, column: 46}},
+          version: {value: 'v1.2.2', position: {line: 7, column: 37}},
         });
     });
     
@@ -136,35 +136,35 @@ describe('Golang go.mod parser test', () => {
       expect(deps.length).equal(8);
       expect(deps[0]).is.eql({
         name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
-        version: {value: '0.1.3-alpha', position: {line: 5, column: 40}},
+        version: {value: 'v0.1.3-alpha', position: {line: 5, column: 39}},
       });
       expect(deps[1]).is.eql({
         name: {value: 'github.com/pierrec/lz4', position: {line: 0, column: 0}},
-        version: {value: '2.5.2-alpha+incompatible', position: {line: 6, column: 35}},
+        version: {value: 'v2.5.2-alpha+incompatible', position: {line: 6, column: 34}},
       });
       expect(deps[2]).is.eql({
         name: {value: 'github.com/davecgh/go-spew', position: {line: 0, column: 0}},
-        version: {value: '1.1.1+incompatible', position: {line: 7, column: 39}},
+        version: {value: 'v1.1.1+incompatible', position: {line: 7, column: 38}},
       });
       expect(deps[3]).is.eql({
         name: {value: 'github.com/pmezard/go-difflib', position: {line: 0, column: 0}},
-        version: {value: '1.3.0+version', position: {line: 8, column: 42}},
+        version: {value: 'v1.3.0+version', position: {line: 8, column: 41}},
       });
       expect(deps[4]).is.eql({
         name: {value: 'github.com/stretchr/testify', position: {line: 0, column: 0}},
-        version: {value: '1.2.2+incompatible-version', position: {line: 9, column: 40}},
+        version: {value: 'v1.2.2+incompatible-version', position: {line: 9, column: 39}},
       });
       expect(deps[5]).is.eql({
         name: {value: 'github.com/regen-network/protobuf', position: {line: 0, column: 0}},
-        version: {value: '1.3.2-alpha.regen.4', position: {line: 10, column: 46}},
+        version: {value: 'v1.3.2-alpha.regen.4', position: {line: 10, column: 45}},
       });
       expect(deps[6]).is.eql({
         name: {value: 'github.com/vmihailenco/msgpack/v5', position: {line: 0, column: 0}},
-        version: {value: '5.0.0-beta.1', position: {line: 11, column: 46}},
+        version: {value: 'v5.0.0-beta.1', position: {line: 11, column: 45}},
       });
       expect(deps[7]).is.eql({
         name: {value: 'github.com/btcsuite/btcd', position: {line: 0, column: 0}},
-        version: {value: '0.20.1-beta', position: {line: 12, column: 37}},
+        version: {value: 'v0.20.1-beta', position: {line: 12, column: 36}},
       });
     });
     
@@ -185,11 +185,11 @@ describe('Golang go.mod parser test', () => {
       expect(deps.length).equal(2);
       expect(deps[0]).is.eql({
         name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
-        version: {value: '0.1.3-alpha', position: {line: 5, column: 40}},
+        version: {value: 'v0.1.3-alpha', position: {line: 5, column: 39}},
       });
       expect(deps[1]).is.eql({
         name: {value: 'github.com/pierrec/lz4', position: {line: 0, column: 0}},
-        version: {value: '2.5.2-alpha+incompatible', position: {line: 6, column: 35}},
+        version: {value: 'v2.5.2-alpha+incompatible', position: {line: 6, column: 34}},
       });
     });
     
@@ -207,11 +207,42 @@ describe('Golang go.mod parser test', () => {
       expect(deps.length).equal(2);
       expect(deps[0]).is.eql({
         name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
-        version: {value: '0.1.3-alpha', position: {line: 5, column: 40}},
+        version: {value: 'v0.1.3-alpha', position: {line: 5, column: 39}},
       });
       expect(deps[1]).is.eql({
         name: {value: 'github.com/pierrec/lz4', position: {line: 0, column: 0}},
-        version: {value: '2.5.2-alpha+incompatible', position: {line: 6, column: 35}},
+        version: {value: 'v2.5.2-alpha+incompatible', position: {line: 6, column: 34}},
+      });
+    });
+
+    it('test single line require statement in go.mod', async () => {
+      const deps = await collector.collect(`
+        module github.com/alecthomas/kingpin
+        go 1.13
+        require github.com/alecthomas/units v0.1.3-alpha
+	require github.com/pierrec/lz4 v2.5.2
+      `);
+      expect(deps.length).equal(2);
+      expect(deps[0]).is.eql({
+        name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
+        version: {value: 'v0.1.3-alpha', position: {line: 4, column: 45}},
+      });
+      expect(deps[1]).is.eql({
+        name: {value: 'github.com/pierrec/lz4', position: {line: 0, column: 0}},
+        version: {value: 'v2.5.2', position: {line: 5, column: 33}},
+      });
+    });
+
+    it('test single require statement with braces in go.mod', async () => {
+      const deps = await collector.collect(`
+        module github.com/alecthomas/kingpin
+        go 1.13
+        require ( github.com/alecthomas/units v0.1.3 )
+      `);
+      expect(deps.length).equal(1);
+      expect(deps[0]).is.eql({
+        name: {value: 'github.com/alecthomas/units', position: {line: 0, column: 0}},
+        version: {value: 'v0.1.3', position: {line: 4, column: 47}},
       });
     });
 });


### PR DESCRIPTION
Resolving below jira issue and fixing version string parsing using regex.

https://issues.redhat.com/browse/APPAI-1484