### PR TITLE
fix: Add code action to trigger full stack report

### DIFF
--- a/src/consumers.ts
+++ b/src/consumers.ts
@@ -202,7 +202,18 @@ Recommendation: ${recommendedVersion}`;
                     range: diagnostic.range,
                     newText: this.changeTo
                 }];
+                let fullStackReport: CodeAction = {
+                    title: "Detailed Vulnerability Report",
+                    diagnostics: [diagnostic],
+                    kind: CodeActionKind.QuickFix,
+                };
+                fullStackReport.command = {
+                  command: "extension.fabric8AnalyticsWidgetFullStack",
+                  title: "Analytics Report",
+                  // arguments: args,
+                };
                 codeActionsMap[diagnostic.message] = codeAction
+                codeActionsMap[diagnostic.message + "1"] = fullStackReport
             }
             return [diagnostic]
         } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -324,6 +324,10 @@ connection.onCodeAction((params, token): CodeAction[] => {
         if (codeAction != null) {
             codeActions.push(codeAction)
         }
+        codeAction = codeActionsMap[diagnostic.message + "1"];
+        if (codeAction != null) {
+            codeActions.push(codeAction)
+        }
     }
     return codeActions;
 });


### PR DESCRIPTION
This PR enables CodeActions to trigger full stack report in the context of each diagnostics. 

Newly added CodeAction would be enabled based on the env variable(PROVIDE_FULLSTACK_ACTION==“true”) so that it shall be enabled only for VSCode.

https://issues.redhat.com/browse/APPAI-1590

<img width="472" alt="Screenshot 2020-10-30 at 2 04 02 PM" src="https://user-images.githubusercontent.com/3874763/97677744-c5d04f00-1ab8-11eb-8e3b-93330142ab06.png">