### PR TITLE
fix: [APPAI-1638] Check for go executable and provide proper error message

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -161,7 +161,11 @@ class GomodDependencyCollector implements IDependencyCollector {
             exec(`${config.golang_executable} list -f '{{ join .Imports "\\n" }}' ./...`,
                    { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
-                    reject(`'${config.golang_executable} list' command failed with error :: ${stderr}`);
+                    if (error.code == 127) { // Invalid command, go executable not found
+                        reject(`Unable to locate '${config.golang_executable}' executable, Restart all instances of visual code editor and try again`)
+                    } else {
+                        reject(`Unable to execute '${config.golang_executable} list' command, run '${config.golang_executable} mod tidy' to know more`);
+                    }
                 } else {
                     resolve(new Set(stdout.toString().split("\n")));
                 }

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -162,7 +162,7 @@ class GomodDependencyCollector implements IDependencyCollector {
                    { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
                     if (error.code == 127) { // Invalid command, go executable not found
-                        reject(`Unable to locate '${config.golang_executable}' executable, Restart all instances of visual code editor and try again`)
+                        reject(`Unable to execute '${config.golang_executable}'`);
                     } else {
                         reject(`Unable to execute '${config.golang_executable} list' command, run '${config.golang_executable} mod tidy' to know more`);
                     }

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -162,7 +162,7 @@ class GomodDependencyCollector implements IDependencyCollector {
                    { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
                     if (error.code == 127) { // Invalid command, go executable not found
-                        reject(`Unable to execute '${config.golang_executable}'`);
+                        reject(`Unable to locate '${config.golang_executable}'`);
                     } else {
                         reject(`Unable to execute '${config.golang_executable} list' command, run '${config.golang_executable} mod tidy' to know more`);
                     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,6 @@ import { NoopVulnerabilityAggregator, GolangVulnerabilityAggregator } from './ag
 import { AnalyticsSource } from './vulnerability';
 import { config } from './config';
 import fetch from 'node-fetch';
-import { exec } from 'child_process';
 
 const url = require('url');
 const winston = require('winston');
@@ -246,37 +245,17 @@ function slicePayload(payload, batchSize, ecosystem): any {
     return reqData;
 }
 
-const golangExecExists = new Promise<Boolean>(resolve => {
-    exec(`which ${config.golang_executable}`, { maxBuffer: 1024 * 1200 }, error => {
-        if (error) {
-            resolve(false);
-        } else {
-            resolve(true);
-        }
-    });
-});
-
 const regexVersion =  new RegExp(/^([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+)$/);
 const sendDiagnostics = async (ecosystem: string, diagnosticFilePath: string, contents: string, collector: IDependencyCollector) => {
     connection.sendNotification('caNotification', {'data': caDefaultMsg});
-
-    if (ecosystem == "golang") {
-        const golangExists = await golangExecExists;
-        if (!golangExists) {
-            connection.console.error(`Golang executable '${config.golang_executable}' not found`);
-            connection.sendNotification('caError', {'data': `Unable to locate '${config.golang_executable}' executable, Restart all instances of visual code editor and try again`});
-            return;
-        }
-    }
-
     let deps = null;
     try {
         deps = await collector.collect(contents);
     } catch (error) {
         // Error can be raised during golang `go list ` command only.
         if (ecosystem == "golang") {
-            connection.console.error(`Command execution failed, something wrong with manifest file go.mod. Error: ${error}`);
-            connection.sendNotification('caError', {'data': `Unable to execute '${config.golang_executable} list' command, run '${config.golang_executable} mod tidy' to resolve dependencies issues`});
+            connection.console.error(`Command execution failed with error: ${error}`);
+            connection.sendNotification('caError', {'data': error});
             return;
         }
     }


### PR DESCRIPTION
LPS should check for go executable path and provide proper error message to VS Code in case of error. This error can happen when LSP server process is not having proper PATH value that contains go executable path.

Fixes jira ticket :: https://issues.redhat.com/browse/APPAI-1638

Error message in case go executable is not found:
![image](https://user-images.githubusercontent.com/13691335/100196642-2b302800-2f1f-11eb-8a22-7fc3bfa6f6de.png)

Error message in case `go list` command fails:
![image](https://user-images.githubusercontent.com/13691335/100196693-3edb8e80-2f1f-11eb-847a-de150a5f0e7b.png)
