### PR TITLE
fix: [APPAI-1618] Handle replace directive from go.mod

### DIFF
--- a/test/gomod.collector.test.ts
+++ b/test/gomod.collector.test.ts
@@ -195,28 +195,87 @@ github.com/btcsuite/btcd`);
 
   it('tests replace statements in go.mod', async () => {
     fake(getGoLangImportsCmd(), `github.com/alecthomas/units
-github.com/pierrec/lz4`);
+github.com/pierrec/lz4
+github.com/davecgh/go-spew
+github.com/pmezard/go-difflib
+github.com/stretchr/testify
+github.com/stretchr/testify/test
+github.com/regen-network/protobuf
+github.com/regen-network/protobuf/multi
+github.com/vmihailenco/msgpack/v5
+github.com/vmihailenco/msgpack/v5/v6
+github.com/btcsuite/btcd`);
     const deps = await collector.collect(`
         module github.com/alecthomas/kingpin
         go 1.13
         require (
           github.com/alecthomas/units v0.1.3-alpha
           github.com/pierrec/lz4 v2.5.2-alpha+incompatible
+          github.com/davecgh/go-spew v1.1.1+incompatible
+          github.com/pmezard/go-difflib v1.3.0
+          github.com/stretchr/testify v1.2.2+incompatible-version
+          github.com/regen-network/protobuf v1.3.2-alpha.regen.4
+          github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1
+          github.com/btcsuite/btcd v0.0.0-20151022065526-2efee857e7cf
         )
         
         replace (
-          github.com/alecthomas/units => github.com/test-user/units v13.3.2 // Required by OLM
+          github.com/alecthomas/units v0.1.3-alpha => github.com/test-user/units v13.3.2 // Required by OLM
+          github.com/alecthomas/units v0.1.3 => github.com/test-user/units v13.3.2 // Required by OLM
           github.com/pierrec/lz4 => github.com/pierrec/lz4 v3.4.2 // Required by prometheus-operator
+          github.com/pierrec/lz4 v3.4.1 => github.com/pierrec/lz4 v3.4.3 // same-module with diff version in replace
+          github.com/davecgh/go-spew v1.1.1+incompatible => github.com/davecgh/go-spew v1.1.2
+          github.com/stretchr/testify => github.com/stretchr-1/testify v1.2.3 // test with module and with one import package
+          github.com/regen-network/protobuf => github.com/regen-network/protobuf1 v1.3.2 // test with module and with one import package
+          github.com/pmezard/go-difflib v1.3.0 => github.com/pmezard/go-difflib v0.0.0-20151022065526-2efee857e7cf // semver to pseudo
+          github.com/btcsuite/btcd v0.0.0-20151022065526-2efee857e7cf => github.com/btcsuite/btcd v0.20.1-beta // pseudo to semver
+          github.com/vmihailenco/msgpack/v5 v5.0.0-beta.1 => ./msgpack/v5 // replace with local module
         )
       `);
-    expect(deps.length).equal(2);
+    expect(deps.length).equal(11);
     expect(deps[0]).is.eql({
-      name: { value: 'github.com/alecthomas/units', position: { line: 0, column: 0 } },
-      version: { value: 'v0.1.3-alpha', position: { line: 5, column: 39 } }
+      name: { value: 'github.com/test-user/units', position: { line: 0, column: 0 } },
+      version: { value: 'v13.3.2', position: { line: 16, column: 82 } }
     });
     expect(deps[1]).is.eql({
       name: { value: 'github.com/pierrec/lz4', position: { line: 0, column: 0 } },
-      version: { value: 'v2.5.2-alpha+incompatible', position: { line: 6, column: 34 } }
+      version: { value: 'v3.4.2', position: { line: 18, column: 60 } }
+    });
+    expect(deps[2]).is.eql({
+      name: { value: 'github.com/davecgh/go-spew', position: { line: 0, column: 0 } },
+      version: { value: 'v1.1.2', position: { line: 20, column: 88 } }
+    });
+    expect(deps[3]).is.eql({
+      name: { value: 'github.com/pmezard/go-difflib', position: { line: 0, column: 0 } },
+      version: { value: 'v0.0.0-20151022065526-2efee857e7cf', position: { line: 23, column: 81 } }
+    });
+    expect(deps[4]).is.eql({
+      name: { value: 'github.com/stretchr-1/testify', position: { line: 0, column: 0 } },
+      version: { value: 'v1.2.3', position: { line: 21, column: 72 } }
+    });
+    expect(deps[5]).is.eql({
+      name: { value: 'github.com/regen-network/protobuf1', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.2', position: { line: 22, column: 83 } }
+    });
+    expect(deps[6]).is.eql({
+      name: { value: 'github.com/vmihailenco/msgpack/v5', position: { line: 0, column: 0 } },
+      version: { value: 'v5.0.0-beta.1', position: { line: 11, column: 45 } }
+    });
+    expect(deps[7]).is.eql({
+      name: { value: 'github.com/btcsuite/btcd', position: { line: 0, column: 0 } },
+      version: { value: 'v0.20.1-beta', position: { line: 24, column: 99 } }
+    });
+    expect(deps[8]).is.eql({
+      name: { value: 'github.com/stretchr-1/testify/test@github.com/stretchr-1/testify', position: { line: 0, column: 0 } },
+      version: { value: 'v1.2.3', position: { line: 21, column: 72 } }
+    });
+    expect(deps[9]).is.eql({
+      name: { value: 'github.com/regen-network/protobuf1/multi@github.com/regen-network/protobuf1', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.2', position: { line: 22, column: 83 } }
+    });
+    expect(deps[10]).is.eql({
+      name: { value: 'github.com/vmihailenco/msgpack/v5/v6@github.com/vmihailenco/msgpack/v5', position: { line: 0, column: 0 } },
+      version: { value: 'v5.0.0-beta.1', position: { line: 11, column: 45 } }
     });
   });
 
@@ -235,12 +294,144 @@ github.com/pierrec/lz4`);
       `);
     expect(deps.length).equal(2);
     expect(deps[0]).is.eql({
+      name: { value: 'github.com/test-user/units', position: { line: 0, column: 0 } },
+      version: { value: 'v13.3.2', position: { line: 9, column: 75 } }
+    });
+    expect(deps[1]).is.eql({
+      name: { value: 'github.com/pierrec/lz4', position: { line: 0, column: 0 } },
+      version: { value: 'v2.5.2-alpha+incompatible', position: { line: 6, column: 34 } }
+    });
+  });
+
+  it('tests multiple line replace statement in go.mod', async () => {
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
+github.com/pierrec/lz4
+github.com/davecgh/go-spew
+github.com/davecgh/go-spew/spew
+github.com/pmezard/go-difflib`);
+    const deps = await collector.collect(`
+        module github.com/alecthomas/kingpin
+        go 1.13
+
+        replace github.com/alecthomas/units => github.com/test-user/units v13.3.2
+
+        require (
+          github.com/alecthomas/units v0.1.3-alpha
+          github.com/pierrec/lz4 v2.5.2-alpha+incompatible
+          github.com/davecgh/go-spew v1.1.1+incompatible
+          github.com/pmezard/go-difflib v1.3.0
+        )
+        
+        replace github.com/pierrec/lz4 v2.5.2-alpha+incompatible => github.com/pierrec/lz4 v2.5.3
+        replace github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.2
+        // replace github.com/pmezard/go-difflib v1.3.0 => github.com/pmezard/go-difflib v1.3.1
+      `);
+    expect(deps.length).equal(5);
+    expect(deps[0]).is.eql({
+      name: { value: 'github.com/test-user/units', position: { line: 0, column: 0 } },
+      version: { value: 'v13.3.2', position: { line: 5, column: 75 } }
+    });
+    expect(deps[1]).is.eql({
+      name: { value: 'github.com/pierrec/lz4', position: { line: 0, column: 0 } },
+      version: { value: 'v2.5.3', position: { line: 14, column: 92 } }
+    });
+    expect(deps[2]).is.eql({
+      name: { value: 'github.com/davecgh/go-spew', position: { line: 0, column: 0 } },
+      version: { value: 'v1.1.2', position: { line: 15, column: 74 } }
+    });
+    expect(deps[3]).is.eql({
+      name: { value: 'github.com/pmezard/go-difflib', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.0', position: { line: 11, column: 41 } }
+    });
+    expect(deps[4]).is.eql({
+      name: { value: 'github.com/davecgh/go-spew/spew@github.com/davecgh/go-spew', position: { line: 0, column: 0 } },
+      version: { value: 'v1.1.2', position: { line: 15, column: 74 } }
+    });
+  });
+
+  
+  it('tests multiple module points to same replace module in go.mod', async () => {
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
+github.com/pierrec/lz4
+github.com/gogo/protobuf
+github.com/golang/protobuf`);
+    const deps = await collector.collect(`
+        module github.com/alecthomas/kingpin
+        go 1.13
+        require (
+          github.com/alecthomas/units v0.1.3-alpha
+          github.com/pierrec/lz4 v2.5.2-alpha+incompatible
+          github.com/gogo/protobuf v1.3.0
+          github.com/golang/protobuf v1.3.4
+        )
+        replace (
+          github.com/golang/protobuf => github.com/gogo/protobuf v1.3.1
+          github.com/gogo/protobuf v1.3.0 => github.com/gogo/protobuf v1.3.1
+        )      
+      `);
+    expect(deps.length).equal(4);
+    expect(deps[0]).is.eql({
       name: { value: 'github.com/alecthomas/units', position: { line: 0, column: 0 } },
       version: { value: 'v0.1.3-alpha', position: { line: 5, column: 39 } }
     });
     expect(deps[1]).is.eql({
       name: { value: 'github.com/pierrec/lz4', position: { line: 0, column: 0 } },
       version: { value: 'v2.5.2-alpha+incompatible', position: { line: 6, column: 34 } }
+    });
+    expect(deps[2]).is.eql({
+      name: { value: 'github.com/gogo/protobuf', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.1', position: { line: 12, column: 71 } }
+    });
+    expect(deps[3]).is.eql({
+      name: { value: 'github.com/gogo/protobuf', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.1', position: { line: 11, column: 66 } }
+    });
+  });
+
+  it('tests replace block before require in go.mod', async () => {
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
+github.com/pierrec/lz4
+github.com/davecgh/go-spew
+github.com/davecgh/go-spew/spew
+github.com/pmezard/go-difflib`);
+    const deps = await collector.collect(`
+        module github.com/alecthomas/kingpin
+        go 1.13
+
+        replace (
+          github.com/alecthomas/units => github.com/test-user/units v13.3.2
+          github.com/pierrec/lz4 v2.5.2-alpha+incompatible => github.com/pierrec/lz4 v2.5.3
+          github.com/davecgh/go-spew => github.com/davecgh/go-spew v1.1.2
+          // replace github.com/pmezard/go-difflib v1.3.0 => github.com/pmezard/go-difflib v1.3.1
+        )
+
+        require (
+          github.com/alecthomas/units v0.1.3-alpha
+          github.com/pierrec/lz4 v2.5.2-alpha+incompatible
+          github.com/davecgh/go-spew v1.1.1+incompatible
+          github.com/pmezard/go-difflib v1.3.0
+        )
+      `);
+    expect(deps.length).equal(5);
+    expect(deps[0]).is.eql({
+      name: { value: 'github.com/test-user/units', position: { line: 0, column: 0 } },
+      version: { value: 'v13.3.2', position: { line: 6, column: 69 } }
+    });
+    expect(deps[1]).is.eql({
+      name: { value: 'github.com/pierrec/lz4', position: { line: 0, column: 0 } },
+      version: { value: 'v2.5.3', position: { line: 7, column: 86 } }
+    });
+    expect(deps[2]).is.eql({
+      name: { value: 'github.com/davecgh/go-spew', position: { line: 0, column: 0 } },
+      version: { value: 'v1.1.2', position: { line: 8, column: 68 } }
+    });
+    expect(deps[3]).is.eql({
+      name: { value: 'github.com/pmezard/go-difflib', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.0', position: { line: 16, column: 41 } }
+    });
+    expect(deps[4]).is.eql({
+      name: { value: 'github.com/davecgh/go-spew/spew@github.com/davecgh/go-spew', position: { line: 0, column: 0 } },
+      version: { value: 'v1.1.2', position: { line: 8, column: 68 } }
     });
   });
 
@@ -257,19 +448,21 @@ github.com/google/go-cmp/cmp/cmpopts`);
       go 1.15
 
       require github.com/google/go-cmp v0.5.2
+
+      replace github.com/google/go-cmp v0.5.2 => github.com/google/go-cmp2 v0.5.2
     `);
     expect(deps.length).equal(3);
     expect(deps[0]).is.eql({
-      name: { value: 'github.com/google/go-cmp', position: { line: 0, column: 0 } },
-      version: { value: 'v0.5.2', position: { line: 6, column: 40 } }
+      name: { value: 'github.com/google/go-cmp2', position: { line: 0, column: 0 } },
+      version: { value: 'v0.5.2', position: { line: 8, column: 76 } }
     });
     expect(deps[1]).is.eql({
-      name: { value: 'github.com/google/go-cmp/cmp@github.com/google/go-cmp', position: { line: 0, column: 0 } },
-      version: { value: 'v0.5.2', position: { line: 6, column: 40 } }
+      name: { value: 'github.com/google/go-cmp2/cmp@github.com/google/go-cmp2', position: { line: 0, column: 0 } },
+      version: { value: 'v0.5.2', position: { line: 8, column: 76 } }
     });
     expect(deps[2]).is.eql({
-      name: { value: 'github.com/google/go-cmp/cmp/cmpopts@github.com/google/go-cmp', position: { line: 0, column: 0 } },
-      version: { value: 'v0.5.2', position: { line: 6, column: 40 } }
+      name: { value: 'github.com/google/go-cmp2/cmp/cmpopts@github.com/google/go-cmp2', position: { line: 0, column: 0 } },
+      version: { value: 'v0.5.2', position: { line: 8, column: 76 } }
     });
   });
 


### PR DESCRIPTION
Golang manifest file go.mod has "replace" directive which needs to be considered while generating CA batch request.

1. Manifest go.mod shall not highlight the vulnerability of actual module in "require" section if there is replace statement for the same module.

2. "replace" section, destination module should be highlighted in case of vulnerability for that module or any packages of the module.