### PR TITLE
fix: [APPAI-1643][Golang]CA might add/update dependencies in go.mod

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -7,7 +7,7 @@ import { Stream } from 'stream';
 import * as Xml2Object from 'xml2object';
 import * as jsonAst from 'json-to-ast';
 import { IPosition, IKeyValueEntry, KeyValueEntry, Variant, ValueType } from './types';
-import { stream_from_string, get_golang_imports_cmd } from './utils';
+import { stream_from_string, getGoLangImportsCmd } from './utils';
 import { config } from './config';
 import { exec } from 'child_process';
 
@@ -180,7 +180,7 @@ class GomodDependencyCollector implements IDependencyCollector {
     async collect(contents: string): Promise<Array<IDependency>> {
         let promiseExec = new Promise<Set<string>>((resolve, reject) => {
             const vscodeRootpath = this.manifestFile.replace("file://", "").replace("/go.mod", "")
-            exec(get_golang_imports_cmd(),
+            exec(getGoLangImportsCmd(),
                 { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
                     if (error.code == 127) { // Invalid command, go executable not found

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -180,7 +180,7 @@ class GomodDependencyCollector implements IDependencyCollector {
     async collect(contents: string): Promise<Array<IDependency>> {
         let promiseExec = new Promise<Set<string>>((resolve, reject) => {
             const vscodeRootpath = this.manifestFile.replace("file://", "").replace("/go.mod", "")
-            exec(`${config.golang_executable} list -f '{{ join .Imports "\\n" }}' ./...`,
+            exec(`${config.golang_executable} list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`,
                    { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
                     if (error.code == 127) { // Invalid command, go executable not found

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -7,7 +7,7 @@ import { Stream } from 'stream';
 import * as Xml2Object from 'xml2object';
 import * as jsonAst from 'json-to-ast';
 import { IPosition, IKeyValueEntry, KeyValueEntry, Variant, ValueType } from './types';
-import { stream_from_string } from './utils';
+import { stream_from_string, get_golang_imports_cmd } from './utils';
 import { config } from './config';
 import { exec } from 'child_process';
 
@@ -180,8 +180,8 @@ class GomodDependencyCollector implements IDependencyCollector {
     async collect(contents: string): Promise<Array<IDependency>> {
         let promiseExec = new Promise<Set<string>>((resolve, reject) => {
             const vscodeRootpath = this.manifestFile.replace("file://", "").replace("/go.mod", "")
-            exec(`${config.golang_executable} list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`,
-                   { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
+            exec(get_golang_imports_cmd(),
+                { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
                     if (error.code == 127) { // Invalid command, go executable not found
                         reject(`Unable to locate '${config.golang_executable}'`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import { Stream, Readable } from 'stream';
 import { IPosition } from './types';
 import { IPositionedString } from './collector';
 import { Position, Range } from 'vscode-languageserver';
+import { config } from './config';
 
 export let stream_from_string = (s: string): Stream => {
   let stream = new Readable();
@@ -49,4 +50,8 @@ export let to_lsp_position = (pos: IPosition): Position => {
 
 export let get_range = (ps: IPositionedString): Range => {
   return _get_range_che(ps);
+};
+
+export let get_golang_imports_cmd = (): string => {
+  return `${config.golang_executable} list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,6 +52,6 @@ export let get_range = (ps: IPositionedString): Range => {
   return _get_range_che(ps);
 };
 
-export let get_golang_imports_cmd = (): string => {
+export let getGoLangImportsCmd = (): string => {
   return `${config.golang_executable} list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`;
 };

--- a/test/gomod.collector.test.ts
+++ b/test/gomod.collector.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { GomodDependencyCollector } from '../src/collector';
-import { config } from '../src/config';
+import { get_golang_imports_cmd } from '../src/utils';
 
 const fake = require('fake-exec');
 
@@ -9,7 +9,7 @@ describe('Golang go.mod parser test', () => {
   const collector: GomodDependencyCollector = new GomodDependencyCollector(fakeSourceRoot);
 
   it('tests valid go.mod', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
@@ -43,7 +43,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests go.mod with comments', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
     const deps = await collector.collect(`// This is start point.
@@ -73,7 +73,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests empty lines in go.mod', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
 github.com/stretchr/testify`);
     const deps = await collector.collect(`
           module github.com/alecthomas/kingpin
@@ -100,7 +100,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests deps with spaces before and after comparators', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
@@ -134,7 +134,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests alpha beta and extra for version in go.mod', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
 github.com/pierrec/lz4
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
@@ -194,7 +194,7 @@ github.com/btcsuite/btcd`);
   });
 
   it('tests replace statements in go.mod', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
 github.com/pierrec/lz4`);
     const deps = await collector.collect(`
         module github.com/alecthomas/kingpin
@@ -221,7 +221,7 @@ github.com/pierrec/lz4`);
   });
 
   it('tests single line replace statement in go.mod', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
 github.com/pierrec/lz4`);
     const deps = await collector.collect(`
         module github.com/alecthomas/kingpin
@@ -245,7 +245,7 @@ github.com/pierrec/lz4`);
   });
 
   it('tests go.mod with a module in import', async () => {
-    fake(`${config.golang_executable} list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(get_golang_imports_cmd(), `fmt
 github.com/google/go-cmp/cmp
 fmt
 github.com/google/go-cmp/cmp
@@ -270,7 +270,7 @@ github.com/google/go-cmp/cmp/cmpopts`);
   });
 
   it('tests go.mod with a module and two package import', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(get_golang_imports_cmd(), `fmt
 github.com/google/go-cmp/cmp
 fmt
 github.com/google/go-cmp/cmp/version
@@ -299,7 +299,7 @@ github.com/google/go-cmp/cmp/cmpopts`);
   });
 
   it('tests go.mod with a module and package of different version', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(get_golang_imports_cmd(), `fmt
 github.com/googleapis/gax-go
 fmt
 github.com/googleapis/gax-go/v2`);
@@ -326,7 +326,7 @@ github.com/googleapis/gax-go/v2`);
   });
 
   it('tests go.mod with one more module and package of different version', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(get_golang_imports_cmd(), `fmt
 github.com/googleapis/gax-go/abc
 fmt
 github.com/googleapis/gax-go/v2`);
@@ -353,7 +353,7 @@ github.com/googleapis/gax-go/v2`);
   });
 
   it('tests go.mod with more module then imports in source', async () => {
-    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(get_golang_imports_cmd(), `fmt
 github.com/googleapis/gax-go/abc
 github.com/alecthomas/units`);
 

--- a/test/gomod.collector.test.ts
+++ b/test/gomod.collector.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { GomodDependencyCollector } from '../src/collector';
-import { get_golang_imports_cmd } from '../src/utils';
+import { getGoLangImportsCmd } from '../src/utils';
 
 const fake = require('fake-exec');
 
@@ -9,7 +9,7 @@ describe('Golang go.mod parser test', () => {
   const collector: GomodDependencyCollector = new GomodDependencyCollector(fakeSourceRoot);
 
   it('tests valid go.mod', async () => {
-    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
@@ -43,7 +43,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests go.mod with comments', async () => {
-    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
     const deps = await collector.collect(`// This is start point.
@@ -73,7 +73,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests empty lines in go.mod', async () => {
-    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/stretchr/testify`);
     const deps = await collector.collect(`
           module github.com/alecthomas/kingpin
@@ -100,7 +100,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests deps with spaces before and after comparators', async () => {
-    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
@@ -134,7 +134,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests alpha beta and extra for version in go.mod', async () => {
-    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/pierrec/lz4
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
@@ -194,7 +194,7 @@ github.com/btcsuite/btcd`);
   });
 
   it('tests replace statements in go.mod', async () => {
-    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/pierrec/lz4`);
     const deps = await collector.collect(`
         module github.com/alecthomas/kingpin
@@ -221,7 +221,7 @@ github.com/pierrec/lz4`);
   });
 
   it('tests single line replace statement in go.mod', async () => {
-    fake(get_golang_imports_cmd(), `github.com/alecthomas/units
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/pierrec/lz4`);
     const deps = await collector.collect(`
         module github.com/alecthomas/kingpin
@@ -245,7 +245,7 @@ github.com/pierrec/lz4`);
   });
 
   it('tests go.mod with a module in import', async () => {
-    fake(get_golang_imports_cmd(), `fmt
+    fake(getGoLangImportsCmd(), `fmt
 github.com/google/go-cmp/cmp
 fmt
 github.com/google/go-cmp/cmp
@@ -270,7 +270,7 @@ github.com/google/go-cmp/cmp/cmpopts`);
   });
 
   it('tests go.mod with a module and two package import', async () => {
-    fake(get_golang_imports_cmd(), `fmt
+    fake(getGoLangImportsCmd(), `fmt
 github.com/google/go-cmp/cmp
 fmt
 github.com/google/go-cmp/cmp/version
@@ -299,7 +299,7 @@ github.com/google/go-cmp/cmp/cmpopts`);
   });
 
   it('tests go.mod with a module and package of different version', async () => {
-    fake(get_golang_imports_cmd(), `fmt
+    fake(getGoLangImportsCmd(), `fmt
 github.com/googleapis/gax-go
 fmt
 github.com/googleapis/gax-go/v2`);
@@ -326,7 +326,7 @@ github.com/googleapis/gax-go/v2`);
   });
 
   it('tests go.mod with one more module and package of different version', async () => {
-    fake(get_golang_imports_cmd(), `fmt
+    fake(getGoLangImportsCmd(), `fmt
 github.com/googleapis/gax-go/abc
 fmt
 github.com/googleapis/gax-go/v2`);
@@ -353,7 +353,7 @@ github.com/googleapis/gax-go/v2`);
   });
 
   it('tests go.mod with more module then imports in source', async () => {
-    fake(get_golang_imports_cmd(), `fmt
+    fake(getGoLangImportsCmd(), `fmt
 github.com/googleapis/gax-go/abc
 github.com/alecthomas/units`);
 

--- a/test/gomod.collector.test.ts
+++ b/test/gomod.collector.test.ts
@@ -9,7 +9,7 @@ describe('Golang go.mod parser test', () => {
   const collector: GomodDependencyCollector = new GomodDependencyCollector(fakeSourceRoot);
 
   it('tests valid go.mod', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
@@ -43,7 +43,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests go.mod with comments', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
     const deps = await collector.collect(`// This is start point.
@@ -73,7 +73,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests empty lines in go.mod', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
 github.com/stretchr/testify`);
     const deps = await collector.collect(`
           module github.com/alecthomas/kingpin
@@ -100,7 +100,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests deps with spaces before and after comparators', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
 github.com/stretchr/testify`);
@@ -134,7 +134,7 @@ github.com/stretchr/testify`);
   });
 
   it('tests alpha beta and extra for version in go.mod', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
 github.com/pierrec/lz4
 github.com/davecgh/go-spew
 github.com/pmezard/go-difflib
@@ -194,7 +194,7 @@ github.com/btcsuite/btcd`);
   });
 
   it('tests replace statements in go.mod', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
 github.com/pierrec/lz4`);
     const deps = await collector.collect(`
         module github.com/alecthomas/kingpin
@@ -221,7 +221,7 @@ github.com/pierrec/lz4`);
   });
 
   it('tests single line replace statement in go.mod', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `github.com/alecthomas/units
 github.com/pierrec/lz4`);
     const deps = await collector.collect(`
         module github.com/alecthomas/kingpin
@@ -245,7 +245,7 @@ github.com/pierrec/lz4`);
   });
 
   it('tests go.mod with a module in import', async () => {
-    fake(`${config.golang_executable} list -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(`${config.golang_executable} list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
 github.com/google/go-cmp/cmp
 fmt
 github.com/google/go-cmp/cmp
@@ -270,7 +270,7 @@ github.com/google/go-cmp/cmp/cmpopts`);
   });
 
   it('tests go.mod with a module and two package import', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
 github.com/google/go-cmp/cmp
 fmt
 github.com/google/go-cmp/cmp/version
@@ -299,7 +299,7 @@ github.com/google/go-cmp/cmp/cmpopts`);
   });
 
   it('tests go.mod with a module and package of different version', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
 github.com/googleapis/gax-go
 fmt
 github.com/googleapis/gax-go/v2`);
@@ -326,7 +326,7 @@ github.com/googleapis/gax-go/v2`);
   });
 
   it('tests go.mod with one more module and package of different version', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
 github.com/googleapis/gax-go/abc
 fmt
 github.com/googleapis/gax-go/v2`);
@@ -353,7 +353,7 @@ github.com/googleapis/gax-go/v2`);
   });
 
   it('tests go.mod with more module then imports in source', async () => {
-    fake(`go list -f '{{ join .Imports "\\n" }}' ./...`, `fmt
+    fake(`go list -mod=readonly -f '{{ join .Imports "\\n" }}' ./...`, `fmt
 github.com/googleapis/gax-go/abc
 github.com/alecthomas/units`);
 


### PR DESCRIPTION
CA might add/update dependencies in go.mod. Adding -mod=readonly during go list command shall avoid go.mod modification.

Fixes jira ticket :: https://issues.redhat.com/browse/APPAI-1643