### PR TITLE
fix: [APPAI-1655] Clearing all diagnostic message in case of error for golang

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -256,6 +256,7 @@ const sendDiagnostics = async (ecosystem: string, diagnosticFilePath: string, co
         if (ecosystem == "golang") {
             connection.console.error(`Command execution failed with error: ${error}`);
             connection.sendNotification('caError', {'data': error});
+            connection.sendDiagnostics({ uri: diagnosticFilePath, diagnostics: [] });
             return;
         }
     }


### PR DESCRIPTION
Upon CA trigger there are cases when in golang can fail to generate data using go list command. In this case plugin still highlights existing go.mod with diagnostic which are not appropriated for modified content. Solution was to clean all diagnostic messages upon error.

Jira ticket :: https://issues.redhat.com/browse/APPAI-1657