### PR TITLE
fix: Use warn level instead error when logging

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -230,7 +230,7 @@ const fetchVulnerabilities = async (reqData) => {
             return response.status;
         }
     } catch(err) {
-        connection.console.error(`Exception while fetch: ${err}`);
+        connection.console.warn(`Exception while fetch: ${err}`);
     }
 };
 


### PR DESCRIPTION
Fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/458

Using `connection.log.error` automatically shows output window of LSP. Switch to `connection.log.warn` instead.