### PR TITLE
fix: [APPAI-1656] Inconsistent trigger behaviour for CA in golang

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -180,7 +180,7 @@ class GomodDependencyCollector implements IDependencyCollector {
         let promiseExec = new Promise<Set<string>>((resolve, reject) => {
             const vscodeRootpath = this.manifestFile.replace("file://", "").replace("/go.mod", "")
             exec(getGoLangImportsCmd(),
-                { cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
+                { shell :process.env["SHELL"], windowsHide: true, cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
                     if (error.code == 127) { // Invalid command, go executable not found
                         reject(`Unable to locate '${config.golang_executable}'`);

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -180,8 +180,9 @@ class GomodDependencyCollector implements IDependencyCollector {
         let promiseExec = new Promise<Set<string>>((resolve, reject) => {
             const vscodeRootpath = this.manifestFile.replace("file://", "").replace("/go.mod", "")
             exec(getGoLangImportsCmd(),
-                { shell :process.env["SHELL"], windowsHide: true, cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
+                { shell: process.env["SHELL"], windowsHide: true, cwd: vscodeRootpath, maxBuffer: 1024 * 1200 }, (error, stdout, stderr) => {
                 if (error) {
+                    console.error(`Command failed, environment SHELL: [${process.env["SHELL"]}] PATH: [${process.env["PATH"]}] CWD: [${process.env["CWD"]}]`)
                     if (error.code == 127) { // Invalid command, go executable not found
                         reject(`Unable to locate '${config.golang_executable}'`);
                     } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -321,7 +321,6 @@ connection.onDidOpenTextDocument((params) => {
 });
 
 connection.onCodeAction((params, token): CodeAction[] => {
-    clearTimeout(checkDelay);
     let codeActions: CodeAction[] = [];
     let hasAnalyticsDiagonostic: boolean = false;
     for (let diagnostic of params.context.diagnostics) {


### PR DESCRIPTION
On LSP we have below code for onCodeAction  and onDidChangeTextDocument
```
connection.onCodeAction((params, token): CodeAction[] => {
    clearTimeout(checkDelay);
    let codeActions: CodeAction[] = [];
connection.onDidChangeTextDocument((params) => {
    /* Update internal state for code lenses */
    server.files.file_data[params.textDocument.uri] = params.contentChanges[0].text;
    clearTimeout(checkDelay);
    checkDelay = setTimeout(() => {
        server.handle_file_event(params.textDocument.uri, server.files.file_data[params.textDocument.uri])
    }, 500)
```
Upon document change, onDidChange gets fired and it starts timer of 500 ms to trigger CA, but before this timer is fired I see onCodeAction() callback, which clears this timer as shown above. I think clearTimeout() from onCodeAction() should not be present.

Fixes jira issue :: https://issues.redhat.com/browse/APPAI-1656