### PR TITLE
fix: [APPAI-1656] Don't clear request aggregation timer on CodeAction request

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -323,7 +323,6 @@ connection.onDidOpenTextDocument((params) => {
 });
 
 connection.onCodeAction((params, token): CodeAction[] => {
-    clearTimeout(checkDelay);
     let codeActions: CodeAction[] = [];
     let hasAnalyticsDiagonostic: boolean = false;
     for (let diagnostic of params.context.diagnostics) {


### PR DESCRIPTION
On LSP we have below code for onCodeAction and onDidChangeTextDocument

```
connection.onCodeAction((params, token): CodeAction[] => {
    clearTimeout(checkDelay);
    let codeActions: CodeAction[] = [];
connection.onDidChangeTextDocument((params) => {
    /* Update internal state for code lenses */
    server.files.file_data[params.textDocument.uri] = params.contentChanges[0].text;
    clearTimeout(checkDelay);
    checkDelay = setTimeout(() => {
        server.handle_file_event(params.textDocument.uri, server.files.file_data[params.textDocument.uri])
    }, 500)
```

Upon document change, onDidChange gets fired and it starts timer of 500 ms to trigger CA, but before this timer is fired I see onCodeAction() callback, which clears this timer as shown above. I think clearTimeout() from onCodeAction() should not be present.

Fixes jira issue :: https://issues.redhat.com/browse/APPAI-1656