### PR TITLE
fix: Clear diagnostics before generating new set of diagnostics

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -251,21 +251,19 @@ function slicePayload(payload, batchSize, ecosystem): any {
 
 const regexVersion =  new RegExp(/^([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+\.)?([a-zA-Z0-9]+)$/);
 const sendDiagnostics = async (ecosystem: string, diagnosticFilePath: string, contents: string, collector: IDependencyCollector) => {
+    // clear all diagnostics
+    connection.sendDiagnostics({ uri: diagnosticFilePath, diagnostics: [] });
     connection.sendNotification('caNotification', {data: caDefaultMsg, done: false, uri: diagnosticFilePath});
     let deps = null;
     try {
         const start = new Date().getTime();
         deps = await collector.collect(contents);
         const end = new Date().getTime();
-        connection.console.log(`manifest parse took ${end - start} ms`);
+        connection.console.log(`manifest parse took ${end - start} ms, found ${deps.length} deps`);
     } catch (error) {
-        // Error can be raised during golang `go list ` command only.
-        if (ecosystem == "golang") {
-            connection.console.warn(`Command execution failed with error: ${error}`);
-            connection.sendNotification('caError', {data: error, uri: diagnosticFilePath});
-            connection.sendDiagnostics({ uri: diagnosticFilePath, diagnostics: [] });
-            return;
-        }
+        connection.console.warn(`Error: ${error}`);
+        connection.sendNotification('caError', {data: error, uri: diagnosticFilePath});
+        return;
     }
 
     let validPackages = deps;


### PR DESCRIPTION
### Steps to reproduce:

1. Create the requirements.txt with following contents,
```
flask == 0.12
```
2. Empty the requirements.txt by selecting all deps in one go

### Actual behaviour:
Not all diagnostics are not cleared

### Expected behaviour:
No diagnostics should be shown

### Root cause:
Empty manifest/manifest with invalid dependency is not triggering CA api call

### Fix:
Clear diagnostics on every manifest change


Fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/465, https://issues.redhat.com/browse/APPAI-1676