### PR TITLE
fix: Avoid excessive sendDiagnostic calls

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -29,7 +29,7 @@ module.exports = {
         {
           path: "analytics-lsp-linux",
           name: "analytics-lsp-linux",
-          label: "analytics-lsp-server"
+          label: "analytics-lsp-linux"
         },
         {
           path: "analytics-lsp-macos",
@@ -44,7 +44,7 @@ module.exports = {
         {
           path: "analytics-lsp-linux.sha256",
           name: "analytics-lsp-linux.sha256",
-          label: "analytics-lsp-server.sha256"
+          label: "analytics-lsp-linux.sha256"
         },
         {
           path: "analytics-lsp-macos.sha256",

--- a/src/server.ts
+++ b/src/server.ts
@@ -238,8 +238,9 @@ function runPipeline(response, diagnostics, packageAggregator, diagnosticFilePat
             totalCount.advisoryCount += secEng.advisoryCount;
             totalCount.exploitCount += secEng.exploitCount;
         }
-        connection.sendDiagnostics({ uri: diagnosticFilePath, diagnostics: diagnostics });
     });
+    connection.sendDiagnostics({ uri: diagnosticFilePath, diagnostics: diagnostics });
+    connection.console.log(`sendDiagnostics: ${diagnostics?.length}`);
 }
 
 /* Slice payload in each chunk size of @batchSize */


### PR DESCRIPTION
There is no use to send diagnostics on every vulnerability from sync loop. It should be sent per batch.

Also fixed release binary linux artefact label.