### PR TITLE
fix: handle empty cases for all manifests

### DIFF
--- a/src/collector/package.json.ts
+++ b/src/collector/package.json.ts
@@ -7,7 +7,7 @@ export class DependencyCollector implements IDependencyCollector {
     constructor(public classes: Array<string> = ["dependencies"]) {}
 
     async collect(contents: string): Promise<Array<IDependency>> {
-      const ast = jsonAst(contents);
+      const ast = jsonAst(contents || '{}');
       return ast.children.
               filter(c => this.classes.includes(c.key.value)).
               flatMap(c => c.value.children).

--- a/test/collector/go.mod.test.ts
+++ b/test/collector/go.mod.test.ts
@@ -72,6 +72,13 @@ github.com/stretchr/testify`);
     });
   });
 
+  it('tests empty go.mod', async () => {
+    fake(getGoLangImportsCmd(), `github.com/alecthomas/units
+github.com/stretchr/testify`);
+    const deps = await collector.collect(``);
+    expect(deps).is.eql([]);
+  });
+
   it('tests empty lines in go.mod', async () => {
     fake(getGoLangImportsCmd(), `github.com/alecthomas/units
 github.com/stretchr/testify`);

--- a/test/collector/package.json.test.ts
+++ b/test/collector/package.json.test.ts
@@ -4,6 +4,11 @@ import { DependencyCollector } from '../../src/collector/package.json';
 describe('npm package.json parser test', () => {
     const collector = new DependencyCollector();
 
+    it('tests empty package.json file content', async () => {
+        const deps = await collector.collect(``);
+        expect(deps.length).equal(0);
+    });
+
     it('tests empty package.json', async () => {
         const deps = await collector.collect(`
         {}

--- a/test/collector/requirements.txt.test.ts
+++ b/test/collector/requirements.txt.test.ts
@@ -45,6 +45,11 @@ describe('PyPi requirements.txt parser test', () => {
         }]);
     });
 
+    it('tests empty requirements.txt', async () => {
+        const deps = await collector.collect(``);
+        expect(deps).is.eql([]);
+    });
+
     it('tests empty lines', async () => {
         const deps = await collector.collect(`
 


### PR DESCRIPTION
Fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/493