### PR TITLE
fix: mute syntax errors from package.json

### DIFF
--- a/src/collector/package.json.ts
+++ b/src/collector/package.json.ts
@@ -7,7 +7,16 @@ export class DependencyCollector implements IDependencyCollector {
     constructor(public classes: Array<string> = ["dependencies"]) {}
 
     async collect(contents: string): Promise<Array<IDependency>> {
-      const ast = jsonAst(contents || '{}');
+      let ast: any;
+      try {
+          ast = jsonAst(contents || '{}');
+      } catch (err) {
+          // doesn't make any sense to throw syntax errors.
+          if (err.name === 'SyntaxError') {
+              return [];
+          }
+          throw err;
+      }
       return ast.children.
               filter(c => this.classes.includes(c.key.value)).
               flatMap(c => c.value.children).

--- a/test/collector/package.json.test.ts
+++ b/test/collector/package.json.test.ts
@@ -16,6 +16,29 @@ describe('npm package.json parser test', () => {
         expect(deps.length).equal(0);
     });
 
+    it('tests invalid token package.json', async () => {
+        const deps = await collector.collect(`
+         {
+             <<<<<
+             "dependencies": {
+                 "hello": "1.0",
+             }
+         }
+        `);
+        expect(deps).eql([]);
+    });
+
+    it('tests invalid package.json', async () => {
+        const deps = await collector.collect(`
+         {
+             "dependencies": {
+                 "hello": "1.0",
+             }
+         }
+        `);
+        expect(deps).eql([]);
+    });
+
     it('tests empty dependencies key', async () => {
         const deps = await collector.collect(`
         {


### PR DESCRIPTION
It doesn't make sense to throw syntax errors.

Fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/513
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>