### PR TITLE
chore: updated Exhort JS API version and modified go.mod collector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.1-ea.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.27",
+        "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.29",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "compare-versions": "^6.0.0-rc.1",
@@ -1090,9 +1090,9 @@
       }
     },
     "node_modules/@RHEcosystemAppEng/exhort-javascript-api": {
-      "version": "0.0.2-ea.27",
-      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.0.2-ea.27/f909d450ca2cf6706f7145e45f94a70bb4747a7b",
-      "integrity": "sha512-gEkXE768huZ5rkS8Zxj1kfPkKQPfBEGwusJ5J8C46CN55y3iDHijrtC2l+SIayGwhsXfxU9MBpqfK92Z326OqQ==",
+      "version": "0.0.2-ea.29",
+      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.0.2-ea.29/e5fab3bc2babc9bc363af7ff3e4745dabf428c5e",
+      "integrity": "sha512-9ZkDEYN63VTlYsUUkIpE/s/ltacGMhavnxQqgJbMwHMsZBkSTVbj3VVeerj3t8hhMHv2s4Lieca6C8BOz021xQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cyclonedx/cyclonedx-library": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "dependencies": {
-    "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.27",
+    "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.29",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "compare-versions": "^6.0.0-rc.1",

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -114,7 +114,7 @@ export class Dependency implements IHashableDependency {
   }
 
   key(): string {
-    return `${this.name.value}${/^[~^]/.test(this.version.value) ? '' : `@${this.version.value}`}`;
+    return `${this.name.value}`;
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -179,10 +179,7 @@ const getCAmsg = (deps, diagnostics, vulnCount): string => {
 function runPipeline(dependencies, diagnostics, packageAggregator, diagnosticFilePath, pkgMap: DependencyMap, vulnCount, provider: IDependencyProvider) {
     dependencies.forEach(d => {
         // match dependency with dependency from package map
-        let pkg = pkgMap.get(d.ref.replace(`pkg:${provider.ecosystem}/`, ''));
-        if (pkg === undefined && provider.ecosystem === 'npm') {
-            pkg = pkgMap.get(d.ref.split('@')[0].replace(`pkg:${provider.ecosystem}/`, ''));
-        }
+        let pkg = pkgMap.get(d.ref.split('@')[0].replace(`pkg:${provider.ecosystem}/`, ''));
         // if dependency mached, run diagnostic
         if (pkg !== undefined) {
             let pipeline = new DiagnosticsPipeline(SecurityEngine, pkg, config, diagnostics, packageAggregator, diagnosticFilePath);
@@ -199,11 +196,12 @@ function runPipeline(dependencies, diagnostics, packageAggregator, diagnosticFil
 const fetchVulnerabilities = async (fileType: string, reqData: any) => {
     
     // set up configuration options for the component analysis request
-    const options = {};
-    options['EXHORT_MVN_PATH'] = globalSettings.mvnExecutable;
-    options['EXHORT_NPM_PATH'] = globalSettings.npmExecutable;
-    options['EXHORT_GO_PATH'] = globalSettings.goExecutable;
-    options['EXHORT_DEV_MODE'] = config.exhort_dev_mode;
+    const options = {
+        'EXHORT_MVN_PATH': globalSettings.mvnExecutable,
+        'EXHORT_NPM_PATH': globalSettings.npmExecutable,
+        'EXHORT_GO_PATH': globalSettings.goExecutable,
+        'EXHORT_DEV_MODE': config.exhort_dev_mode,
+    };
     if (globalSettings.exhortSnykToken !== '') {
         options['EXHORT_SNYK_TOKEN'] = globalSettings.exhortSnykToken;
     }

--- a/test/collector.test.ts
+++ b/test/collector.test.ts
@@ -25,7 +25,7 @@ describe('Collector util test', () => {
   it('create map for maven dependecies', async () => {
     const ecosystem = 'maven';
     const map = new DependencyMap(reqDeps);
-    expect(map.get(resDeps[0].ref.replace(`pkg:${ecosystem}/`, ''))).to.eql(reqDeps[0]);
-    expect(map.get(resDeps[1].ref.replace(`pkg:${ecosystem}/`, ''))).to.eql(reqDeps[1]);
+    expect(map.get(resDeps[0].ref.split('@')[0].replace(`pkg:${ecosystem}/`, ''))).to.eql(reqDeps[0]);
+    expect(map.get(resDeps[1].ref.split('@')[0].replace(`pkg:${ecosystem}/`, ''))).to.eql(reqDeps[1]);
   });
 })

--- a/test/providers/go.mod.test.ts
+++ b/test/providers/go.mod.test.ts
@@ -391,4 +391,44 @@ describe('Golang go.mod parser test', () => {
       version: { value: 'v2.0.5', position: { line: 8, column: 41 } }
     });
   });
+
+  it('tests exclude statements in go.mod', async () => {
+    const deps = await provider.collect(`
+      module test/data/sample1
+
+      go 1.15
+
+      require (
+        github.com/googleapis/gax-go v1.0.3
+        github.com/googleapis/gax-go/v2 v2.0.5
+        github.com/gogo/protobuf v1.3.0
+        github.com/golang/protobuf v1.3.4
+      )
+
+      exclude (
+        github.com/googleapis/gax-go v1.0.3
+        github.com/googleapis/gax-go/v2 v2.0.5
+      )
+
+      exclude github.com/gogo/protobuf v1.3.0
+
+    `);
+    expect(deps.length).equal(4);
+    expect(deps[0]).is.eql({
+      name: { value: 'github.com/googleapis/gax-go', position: { line: 0, column: 0 } },
+      version: { value: 'v1.0.3', position: { line: 7, column: 38 } }
+    });
+    expect(deps[1]).is.eql({
+      name: { value: 'github.com/googleapis/gax-go/v2', position: { line: 0, column: 0 } },
+      version: { value: 'v2.0.5', position: { line: 8, column: 41 } }
+    });
+    expect(deps[2]).is.eql({
+      name: { value: 'github.com/gogo/protobuf', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.0', position: { line: 9, column: 34 } }
+    });
+    expect(deps[3]).is.eql({
+      name: { value: 'github.com/golang/protobuf', position: { line: 0, column: 0 } },
+      version: { value: 'v1.3.4', position: { line: 10, column: 36 } }
+    });
+  });
 });


### PR DESCRIPTION
1. Updated Exhort Javascript API version to 0.0.2-ea.29
2. modified go.mod collector to ignore excluded dependencies