### PR TITLE
feat: add RHDA_TOKEN param to Exhort JS API request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4293,9 +4293,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ class Config
     npm_executable:           string;
     go_executable:            string;
     exhort_dev_mode:          string;
+    telemetry_id:             string;
 
     constructor() {
         // TODO: this needs to be configurable
@@ -30,6 +31,7 @@ class Config
         this.npm_executable = process.env.NPM_EXECUTABLE || 'npm';
         this.go_executable = process.env.GO_EXECUTABLE || 'go';
         this.exhort_dev_mode = process.env.EXHORT_DEV_MODE || 'false';
+        this.telemetry_id = process.env.TELEMETRY_ID || '';
     }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,6 @@
 'use strict';
 
 import * as path from 'path';
-import * as fs from 'fs';
 
 import {
     createConnection,
@@ -27,7 +26,6 @@ import {
     TextDocument
 } from 'vscode-languageserver-textdocument';
 
-import { execSync } from 'child_process';
 import exhort from '@RHEcosystemAppEng/exhort-javascript-api';
 
 
@@ -200,7 +198,8 @@ const fetchVulnerabilities = async (fileType: string, reqData: any) => {
         'EXHORT_MVN_PATH': globalSettings.mvnExecutable,
         'EXHORT_NPM_PATH': globalSettings.npmExecutable,
         'EXHORT_GO_PATH': globalSettings.goExecutable,
-        'EXHORT_DEV_MODE': config.exhort_dev_mode
+        'EXHORT_DEV_MODE': config.exhort_dev_mode,
+        'RHDA_TOKEN': config.telemetry_id
     };
     if (globalSettings.exhortSnykToken !== '') {
         options['EXHORT_SNYK_TOKEN'] = globalSettings.exhortSnykToken;


### PR DESCRIPTION
Passed the TELEMETRY_ID environment variable from VSCode extension (where is it generated) to LSP Server.
Included TELEMETRY_ID as RHDA_TOKEN environment variable in options passed to Exhort JS API component analysis request.