### PR TITLE
fix: python package inclusion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.1-ea.15",
       "license": "Apache-2.0",
       "dependencies": {
-        "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.45",
+        "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.46",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "json-to-ast": "^2.1.0",
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@RHEcosystemAppEng/exhort-javascript-api": {
-      "version": "0.0.2-ea.45",
-      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.0.2-ea.45/b848a4bef4a0c9148c5e2376e5e4a6829e1dd764",
-      "integrity": "sha512-scNsy3Yl7ifQ5fSNqowKNssiRB3i84m91SAjIJlIf40vupD/ekCQaQDjxD3e6X/c/QflCo8extAilaarcnp1Uw==",
+      "version": "0.0.2-ea.46",
+      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.0.2-ea.46/7ee5f43f61159f1240a9dd5cecebf6d9523a450f",
+      "integrity": "sha512-Mt2B9ygL5qnlH1OU4UDMcGF7ZNvLKYsoZJV4Yi7jA/8sfqIhyZOrqE8WaulHE9dD5whYcWN6ozcN5jldW4akpg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "dependencies": {
-    "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.45",
+    "@RHEcosystemAppEng/exhort-javascript-api": "^0.0.2-ea.46",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "json-to-ast": "^2.1.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,7 +28,7 @@ class Config
         this.utmSource = process.env.VSCEXT_UTM_SOURCE || '';
         this.exhortDevMode = process.env.VSCEXT_EXHORT_DEV_MODE || 'false';
         this.exhortSnykToken = process.env.VSCEXT_EXHORT_SNYK_TOKEN || '';
-        this.matchManifestVersions = process.env.VSCEXT_MATCH_MANIFEST_VERSIONS;
+        this.matchManifestVersions = process.env.VSCEXT_MATCH_MANIFEST_VERSIONS || 'true';
         this.exhortMvnPath = process.env.VSCEXT_EXHORT_MVN_PATH || 'mvn';
         this.exhortNpmPath = process.env.VSCEXT_EXHORT_NPM_PATH || 'npm';
         this.exhortGoPath = process.env.VSCEXT_EXHORT_GO_PATH || 'go';

--- a/src/providers/requirements.txt.ts
+++ b/src/providers/requirements.txt.ts
@@ -21,7 +21,7 @@ class NaivePyParser {
             // skip empty lines
             if (pkgName.length > 0) {
                 const version = (parsedRequirement[1] || '').trim();
-                const entry: IKeyValueEntry = new KeyValueEntry(pkgName, { line: 0, column: 0 });
+                const entry: IKeyValueEntry = new KeyValueEntry(pkgName.toLowerCase(), { line: 0, column: 0 });
                 entry.value = new Variant(ValueType.String, version);
                 entry.valuePosition = { line: index + 1, column: req.indexOf(version) + 1 };
                 dependencies.push(new Dependency(entry));

--- a/test/providers/requirements.txt.test.ts
+++ b/test/providers/requirements.txt.test.ts
@@ -6,7 +6,7 @@ describe('PyPi requirements.txt parser test', () => {
 
     it('tests valid requirements.txt', async () => {
         const deps = await collector.collect(`a==1
-            b==2.1.1
+            B==2.1.1
             c>=10.1
             d<=20.1.2.3.4.5.6.7.8
         `);


### PR DESCRIPTION
1. Convert python package name key value to lowercase to recognize vulnerabilities received by Exhort
2. Upgrade Exhort JavaScript API version to 0.0.2-ea.46