### PR TITLE
feat: add vulnerability alert severity setting

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ class Config
     utmSource:                                      string;
     exhortSnykToken:                                string;
     matchManifestVersions:                          string;
+    vulnerabilityAlertSeverity:                     string;
     exhortMvnPath:                                  string;
     exhortNpmPath:                                  string;
     exhortGoPath:                                   string;
@@ -34,6 +35,7 @@ class Config
         this.utmSource = process.env.VSCEXT_UTM_SOURCE || '';
         this.exhortSnykToken = process.env.VSCEXT_EXHORT_SNYK_TOKEN || '';
         this.matchManifestVersions = process.env.VSCEXT_MATCH_MANIFEST_VERSIONS || 'true';
+        this.vulnerabilityAlertSeverity = process.env.VSCEXT_VULNERABILITY_ALERT_SEVERITY || 'Error';
         this.exhortMvnPath = process.env.VSCEXT_EXHORT_MVN_PATH || 'mvn';
         this.exhortNpmPath = process.env.VSCEXT_EXHORT_NPM_PATH || 'npm';
         this.exhortGoPath = process.env.VSCEXT_EXHORT_GO_PATH || 'go';
@@ -52,6 +54,7 @@ class Config
 
         this.exhortSnykToken = rhdaData.exhortSnykToken;
         this.matchManifestVersions = rhdaData.matchManifestVersions ? 'true' : 'false';
+        this.vulnerabilityAlertSeverity = rhdaData.vulnerabilityAlertSeverity;
         this.exhortMvnPath = rhdaData.mvn.executable.path || 'mvn';
         this.exhortNpmPath = rhdaData.npm.executable.path || 'npm';
         this.exhortGoPath = rhdaData.go.executable.path || 'go';

--- a/src/diagnosticsHandler.ts
+++ b/src/diagnosticsHandler.ts
@@ -83,7 +83,7 @@ class DiagnosticsPipeline implements IDiagnosticsPipeline {
 
                 dependencyData.forEach(dd => {
     
-                    const actionRef = vulnerabilityDiagnostic.severity === 1 ? dd.remediationRef : dd.recommendationRef;
+                    const actionRef = vulnerabilityDiagnostic.severity < 3 ? dd.remediationRef : dd.recommendationRef;
 
                     if (actionRef) {
                         this.createCodeAction(loc, actionRef, dependency.context, dd.sourceId, vulnerabilityDiagnostic);

--- a/src/vulnerability.ts
+++ b/src/vulnerability.ts
@@ -9,6 +9,7 @@ import { Range } from 'vscode-languageserver';
 import { IDependencyProvider } from './collector';
 import { DependencyData } from './componentAnalysis';
 import { RHDA_DIAGNOSTIC_SOURCE } from './constants';
+import { globalConfig } from './config';
 
 /**
  * Stores vulnerability data of a specific dependency.
@@ -57,9 +58,21 @@ Recommendation: ${this.provider.resolveDependencyFromReference(dependencyData.re
      */
     getDiagnostic(): Diagnostic {
         
-        const hasIssues = this.dependencyData.some(data => data.issuesCount > 0);
+        let vulnerabilityAlertSeverity: DiagnosticSeverity;
+        switch (globalConfig.vulnerabilityAlertSeverity) {
+            case 'Error':
+                vulnerabilityAlertSeverity = DiagnosticSeverity.Error;
+                break;
+            case 'Warning':
+                vulnerabilityAlertSeverity = DiagnosticSeverity.Warning;
+                break;
+            default:
+                vulnerabilityAlertSeverity = DiagnosticSeverity.Error;
+                break;
+        }
 
-        const diagnosticSeverity = hasIssues ? DiagnosticSeverity.Error : DiagnosticSeverity.Information;
+        const hasIssues = this.dependencyData.some(data => data.issuesCount > 0);
+        const diagnosticSeverity = hasIssues ? vulnerabilityAlertSeverity : DiagnosticSeverity.Information;
 
         const messages = this.dependencyData.map(dd => {
             if (hasIssues && dd.issuesCount > 0) {

--- a/test/vulnerability.test.ts
+++ b/test/vulnerability.test.ts
@@ -1,10 +1,12 @@
 'use strict';
 
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import { Range } from 'vscode-languageserver';
 
 import { DependencyProvider } from '../src/providers/pom.xml';
 import { Vulnerability } from '../src/vulnerability';
+import * as config from '../src/config';
 
 describe('Vulnerability tests', () => {
     const mavenDependencyProvider: DependencyProvider = new DependencyProvider();
@@ -32,6 +34,11 @@ describe('Vulnerability tests', () => {
     }
 
     it('should return diagnostic with vulnerabilities for single source', async () => {
+        let globalConfig = {
+            vulnerabilityAlertSeverity: 'Error'
+        };
+        sinon.stub(config, 'globalConfig').value(globalConfig);
+
         const mockDependencyData: MockDependencyData[] = [
             new MockDependencyData('snyk(snyk)', 2, '', 'mockRemediationRef', 'HIGH')
         ];
@@ -53,6 +60,11 @@ describe('Vulnerability tests', () => {
     });
 
     it('should return diagnostic with vulnerabilities for multi source', async () => {
+        let globalConfig = {
+            vulnerabilityAlertSeverity: 'Warning'
+        };
+        sinon.stub(config, 'globalConfig').value(globalConfig);
+
         const mockDependencyData: MockDependencyData[] = [
             new MockDependencyData('snyk(snyk)', 2, '', 'mockRemediationRef', 'HIGH'),
             new MockDependencyData('oss(oss)', 3, '', 'mockRemediationRef', 'LOW')
@@ -79,6 +91,11 @@ describe('Vulnerability tests', () => {
     });
 
     it('should return diagnostic without vulnerabilities and with recommendation for single source', async () => {
+        let globalConfig = {
+            vulnerabilityAlertSeverity: ''
+        };
+        sinon.stub(config, 'globalConfig').value(globalConfig);
+
         const mockDependencyData: MockDependencyData[] = [
             new MockDependencyData('snyk(snyk)', 0, mockRecommendationRef, '', 'NONE')
         ];


### PR DESCRIPTION
Added vulnerability alert severity setting which will allow the user to choose to receive inline dependency vulnerability alerts at Error or Warning level.  
Solution to enhancement issue https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/597