### PR TITLE
fix: upgrade to JS API version supporting pom modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.5",
+        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.11",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "json-to-ast": "^2.1.0",
@@ -837,9 +837,9 @@
       }
     },
     "node_modules/@RHEcosystemAppEng/exhort-javascript-api": {
-      "version": "0.1.1-ea.5",
-      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.1.1-ea.5/2cbd94284336733cbb2e3aa8c931ae6b2c1f5d8d",
-      "integrity": "sha512-VBIbeUvBw8DjTNHrBTVvqt2UrdHybApTsopXurlLWjsbmK4R8SJO0zUiQXcxDOyxY40moiNr2gncrcMN3tTRVA==",
+      "version": "0.1.1-ea.11",
+      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.1.1-ea.11/ab70476745966dac2dfe21e7b5dd5ce1ac7f1456",
+      "integrity": "sha512-6+lFREk40FMtxNPk49YHuC1M+oSIIuSxSO7EmnnDOENYzr4ltcjAsJ7rTo0Evfxkgcur9j7Az2K1TESYZcPOfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "dependencies": {
-    "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.5",
+    "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.11",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "json-to-ast": "^2.1.0",

--- a/src/componentAnalysis.ts
+++ b/src/componentAnalysis.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import * as path from 'path';
+import { URL } from 'url';
 import exhort from '@RHEcosystemAppEng/exhort-javascript-api';
 
 import { connection } from './server';
@@ -177,7 +178,7 @@ async function executeComponentAnalysis (diagnosticFilePath: string, contents: s
         options['EXHORT_SNYK_TOKEN'] = globalConfig.exhortSnykToken;
     }
 
-    const componentAnalysisJson = await exhort.componentAnalysis(path.basename(diagnosticFilePath), contents, options); // Execute component analysis
+    const componentAnalysisJson = await exhort.componentAnalysis(path.basename(diagnosticFilePath), contents, options, (new URL(diagnosticFilePath)).pathname); // Execute component analysis
 
     return new AnalysisResponse(componentAnalysisJson, diagnosticFilePath);
 }


### PR DESCRIPTION
Upgrade to Exhort Javascript API that enables and supports analysis of pom.xml manifests that include local modules and parent pom.
Fix to Issue https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/667
