### PR TITLE
fix: view problem panel and ca triggers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fabric8-analytics/fabric8-analytics-lsp-server",
-  "version": "0.9.1-ea.0",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fabric8-analytics/fabric8-analytics-lsp-server",
-      "version": "0.9.1-ea.0",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fabric8-analytics/fabric8-analytics-lsp-server",
   "description": "LSP Server for Red Hat Dependency Analytics",
-  "version": "0.9.1-ea.0",
+  "version": "0.9.2",
   "author": "Red Hat",
   "contributors": [
     {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@
 /**
  * Default source name for the Red Hat Dependency Analytics extension in diagnostics.
  */
-export const RHDA_DIAGNOSTIC_SOURCE = '\nRed Hat Dependency Analytics Plugin';
+export const RHDA_DIAGNOSTIC_SOURCE = 'Red Hat Dependency Analytics Plugin';
 /**
  * Placeholder used as a version for dependency templates.
  */

--- a/src/vulnerability.ts
+++ b/src/vulnerability.ts
@@ -83,7 +83,7 @@ Recommendation: ${this.provider.resolveDependencyFromReference(dependencyData.re
             return '';
         });
     
-        const message = `${this.provider.resolveDependencyFromReference(this.ref)}\n\n${messages.join('\n\n')}`;
+        const message = `${this.provider.resolveDependencyFromReference(this.ref)}\n\n${messages.join('\n\n')}\n`;
 
         return {
             severity: diagnosticSeverity,

--- a/test/providers/pom.xml.test.ts
+++ b/test/providers/pom.xml.test.ts
@@ -153,7 +153,7 @@ describe('Java Maven pom.xml parser tests', () => {
         ]);
     });
 
-    it('test duplicate dependencies where none specify a version', async () => {
+    it('tests duplicate dependencies where none specify a version', async () => {
         const pom = `
             <project>
                 <dependencies>


### PR DESCRIPTION
1.  Fixed the "source" attribute, "Red Hat Dependency Analytics Plugin", in Diagnostics which has been obscured from view in the "View Problem" panel due to VScode  "View Problem" panel format.
2. Disabled Component Analysis trigger for text document edits due to the inability to maintain compatibility with newer features introduced in RHDA version 0.9.2