### PR TITLE
chore: remove redundant image scanning settings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -30,16 +30,11 @@ class Config
     exhortPipPath:                                  string;
     exhortSyftPath:                                 string;
     exhortSyftConfigPath:                           string;
-    exhortSyftImageSource:                          string;
     exhortSkopeoPath:                               string;
     exhortSkopeoConfigPath:                         string;
-    exhortImageServiceEndpoint:                     string;
     exhortDockerPath:                               string;
     exhortPodmanPath:                               string;
     exhortImagePlatform:                            string;
-    exhortImageOS:                                  string;
-    exhortImageArch:                                string;
-    exhortImageVariant:                             string;
 
     private readonly DEFAULT_VULNERABILITY_ALERT_SEVERITY = 'Error';
     private readonly DEFAULT_MVN_EXECUTABLE = 'mvn';
@@ -82,16 +77,11 @@ class Config
         this.exhortPipPath = process.env.VSCEXT_EXHORT_PIP_PATH || this.DEFAULT_PIP_EXECUTABLE;
         this.exhortSyftPath = process.env.VSCEXT_EXHORT_SYFT_PATH || this.DEFAULT_SYFT_EXECUTABLE;
         this.exhortSyftConfigPath = process.env.VSCEXT_EXHORT_SYFT_CONFIG_PATH || '';
-        this.exhortSyftImageSource = process.env.VSCEXT_EXHORT_SYFT_IMAGE_SOURCE || '';
         this.exhortSkopeoPath = process.env.VSCEXT_EXHORT_SKOPEO_PATH || this.DEFAULT_SKOPEO_EXECUTABLE;
         this.exhortSkopeoConfigPath = process.env.VSCEXT_EXHORT_SKOPEO_CONFIG_PATH || '';
-        this.exhortImageServiceEndpoint = process.env.VSCEXT_EXHORT_IMAGE_SERVICE_ENDPOINT || '';
         this.exhortDockerPath = process.env.VSCEXT_EXHORT_DOCKER_PATH || this.DEFAULT_DOCKER_EXECUTABLE;
         this.exhortPodmanPath = process.env.VSCEXT_EXHORT_PODMAN_PATH || this.DEFAULT_PODMAN_EXECUTABLE;
         this.exhortImagePlatform = process.env.VSCEXT_EXHORT_IMAGE_PLATFORM || '';
-        this.exhortImageOS = process.env.VSCEXT_EXHORT_IMAGE_OS || '';
-        this.exhortImageArch = process.env.VSCEXT_EXHORT_IMAGE_ARCH || '';
-        this.exhortImageVariant = process.env.VSCEXT_EXHORT_IMAGE_VARIANT || '';
     }
 
     /**
@@ -114,16 +104,11 @@ class Config
         this.exhortPipPath = rhdaConfig.pip.executable.path || this.DEFAULT_PIP_EXECUTABLE;
         this.exhortSyftPath = rhdaConfig.syft.executable.path || this.DEFAULT_SYFT_EXECUTABLE;
         this.exhortSyftConfigPath = rhdaConfig.syft.config.path;
-        this.exhortSyftImageSource = rhdaConfig.syft.imageSource;
         this.exhortSkopeoPath = rhdaConfig.skopeo.executable.path || this.DEFAULT_SKOPEO_EXECUTABLE;
         this.exhortSkopeoConfigPath = rhdaConfig.skopeo.config.path;
-        this.exhortImageServiceEndpoint = rhdaConfig.image.serviceEndpoint;
         this.exhortDockerPath = rhdaConfig.docker.executable.path || this.DEFAULT_DOCKER_EXECUTABLE;
         this.exhortPodmanPath = rhdaConfig.podman.executable.path || this.DEFAULT_PODMAN_EXECUTABLE;
-        this.exhortImagePlatform = rhdaConfig.image.platform;
-        this.exhortImageOS = rhdaConfig.image.OS;
-        this.exhortImageArch = rhdaConfig.image.arch;
-        this.exhortImageVariant = rhdaConfig.image.variant;
+        this.exhortImagePlatform = rhdaConfig.imagePlatform;
     }
 
     /**

--- a/src/imageAnalysis/analysis.ts
+++ b/src/imageAnalysis/analysis.ts
@@ -206,16 +206,11 @@ interface IOptions {
     RHDA_SOURCE: string;
     EXHORT_SYFT_PATH: string;
     EXHORT_SYFT_CONFIG_PATH: string;
-    EXHORT_SYFT_IMAGE_SOURCE: string;
     EXHORT_SKOPEO_PATH: string;
     EXHORT_SKOPEO_CONFIG_PATH: string;
-    EXHORT_IMAGE_SERVICE_ENDPOINT: string;
     EXHORT_DOCKER_PATH: string;
     EXHORT_PODMAN_PATH: string;
     EXHORT_IMAGE_PLATFORM: string;
-    EXHORT_IMAGE_OS: string;
-    EXHORT_IMAGE_ARCH: string;
-    EXHORT_IMAGE_VARIANT: string;
 }
 
 /**
@@ -270,16 +265,11 @@ async function executeImageAnalysis(diagnosticFilePath: string, images:  IImage[
         'RHDA_SOURCE': globalConfig.utmSource,
         'EXHORT_SYFT_PATH': globalConfig.exhortSyftPath,
         'EXHORT_SYFT_CONFIG_PATH': globalConfig.exhortSyftConfigPath,
-        'EXHORT_SYFT_IMAGE_SOURCE': globalConfig.exhortSyftImageSource,
         'EXHORT_SKOPEO_PATH': globalConfig.exhortSkopeoPath,
         'EXHORT_SKOPEO_CONFIG_PATH': globalConfig.exhortSkopeoConfigPath,
-        'EXHORT_IMAGE_SERVICE_ENDPOINT': globalConfig.exhortImageServiceEndpoint,
         'EXHORT_DOCKER_PATH': globalConfig.exhortDockerPath,
         'EXHORT_PODMAN_PATH': globalConfig.exhortPodmanPath,
         'EXHORT_IMAGE_PLATFORM': globalConfig.exhortImagePlatform,
-        'EXHORT_IMAGE_OS': globalConfig.exhortImageOS,
-        'EXHORT_IMAGE_ARCH': globalConfig.exhortImageArch,
-        'EXHORT_IMAGE_VARIANT': globalConfig.exhortImageVariant
     };
 
     const imageAnalysisJson = await imageAnalysisService(images, options);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -46,19 +46,12 @@ describe('Config tests', () => {
         syft: {
             executable: { path: 'mockPath' },
             config: { path: 'mockPath' },
-            imageSource: 'mockSource'
         },
         skopeo: {
             executable: { path: 'mockPath' },
             config: { path: 'mockPath' }
         },
-        image: {
-            serviceEndpoint: 'mockServiceEndpoint',
-            platform: 'mockPlatform',
-            OS: 'mockOS',
-            arch: 'mockArch',
-            variant: 'mockVariant'
-        }, 
+        imagePlatform: 'mockPlatform',
         docker: {
             executable: { path: 'mockPath' }
         },
@@ -98,19 +91,12 @@ describe('Config tests', () => {
         syft: {
             executable: { path: '' },
             config: { path: '' },
-            imageSource: ''
         },
         skopeo: {
             executable: { path: '' },
             config: { path: '' }
         },
-        image: {
-            serviceEndpoint: '',
-            platform: '',
-            OS: '',
-            arch: '',
-            variant: ''
-        }, 
+        imagePlatform: '',
         docker: {
             executable: { path: '' }
         },
@@ -139,16 +125,11 @@ describe('Config tests', () => {
         expect(mockConfig.exhortPipPath).to.eq('pip');
         expect(mockConfig.exhortSyftPath).to.eq('syft');
         expect(mockConfig.exhortSyftConfigPath).to.eq('');
-        expect(mockConfig.exhortSyftImageSource).to.eq('');
         expect(mockConfig.exhortSkopeoPath).to.eq('skopeo');
         expect(mockConfig.exhortSkopeoConfigPath).to.eq('');
-        expect(mockConfig.exhortImageServiceEndpoint).to.eq('');
         expect(mockConfig.exhortDockerPath).to.eq('docker');
         expect(mockConfig.exhortPodmanPath).to.eq('podman');
         expect(mockConfig.exhortImagePlatform).to.eq('');
-        expect(mockConfig.exhortImageOS).to.eq('');
-        expect(mockConfig.exhortImageArch).to.eq('');
-        expect(mockConfig.exhortImageVariant).to.eq('');
     });
     
     it('should update configuration based on provided data', () => {
@@ -169,16 +150,11 @@ describe('Config tests', () => {
         expect(mockConfig.exhortPipPath).to.eq('mockPath');   
         expect(mockConfig.exhortSyftPath).to.eq('mockPath');
         expect(mockConfig.exhortSyftConfigPath).to.eq('mockPath');
-        expect(mockConfig.exhortSyftImageSource).to.eq('mockSource');
         expect(mockConfig.exhortSkopeoPath).to.eq('mockPath');
         expect(mockConfig.exhortSkopeoConfigPath).to.eq('mockPath');
-        expect(mockConfig.exhortImageServiceEndpoint).to.eq('mockServiceEndpoint');
         expect(mockConfig.exhortDockerPath).to.eq('mockPath');
         expect(mockConfig.exhortPodmanPath).to.eq('mockPath');
         expect(mockConfig.exhortImagePlatform).to.eq('mockPlatform');
-        expect(mockConfig.exhortImageOS).to.eq('mockOS');
-        expect(mockConfig.exhortImageArch).to.eq('mockArch');
-        expect(mockConfig.exhortImageVariant).to.eq('mockVariant');     
     });
 
     it('should update configuration based on provided partial data', () => {
@@ -199,16 +175,11 @@ describe('Config tests', () => {
         expect(mockConfig.exhortPipPath).to.eq('pip');    
         expect(mockConfig.exhortSyftPath).to.eq('syft');
         expect(mockConfig.exhortSyftConfigPath).to.eq('');
-        expect(mockConfig.exhortSyftImageSource).to.eq('');
         expect(mockConfig.exhortSkopeoPath).to.eq('skopeo');
         expect(mockConfig.exhortSkopeoConfigPath).to.eq('');
-        expect(mockConfig.exhortImageServiceEndpoint).to.eq('');
         expect(mockConfig.exhortDockerPath).to.eq('docker');
         expect(mockConfig.exhortPodmanPath).to.eq('podman');
         expect(mockConfig.exhortImagePlatform).to.eq('');
-        expect(mockConfig.exhortImageOS).to.eq('');
-        expect(mockConfig.exhortImageArch).to.eq('');
-        expect(mockConfig.exhortImageVariant).to.eq('');     
     });
 
     it('should set Exhort Snyk Token', () => {


### PR DESCRIPTION
removed image scanning settings:
EXHORT_SYFT_IMAGE_SOURCE
EXHORT_IMAGE_SERVICE_ENDPOINT
EXHORT_IMAGE_OS
EXHORT_IMAGE_ARCH
EXHORT_IMAGE_VARIANT