### PR TITLE
fix: version detection when using arguments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.772",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.772.tgz",
-      "integrity": "sha512-jFfEbxR/abTTJA3ci+2ok1NTuOBBtB4jH+UT6PUmRN+DY3WSD4FFRsgoVQ+QNIJ0T7wrXwzsWCI2WKC46b++2A=="
+      "version": "1.4.774",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.774.tgz",
+      "integrity": "sha512-132O1XCd7zcTkzS3FgkAzKmnBuNJjK8WjcTtNuoylj7MYbqw5eXehjQ5OK91g0zm7OTKIPeaAG4CPoRfD9M1Mg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2073,9 +2073,9 @@
       "integrity": "sha512-nUX94P84wE3gcem12g4FAH3xV7BmcCoV8FXcFVV+NIQAOwRJnyqVKhdGd9DqI4CunW+wOZhVBGKI6Jut/OlLTw=="
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
-      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
       "funding": [
         {
           "type": "github",

--- a/src/providers/build.gradle.ts
+++ b/src/providers/build.gradle.ts
@@ -141,7 +141,7 @@ export class DependencyProvider extends EcosystemDependencyResolver implements I
         // determine dependency version
         const depVersion: string = myClassObj.version;
         if (depVersion) {
-         dep.version = { value: depVersion, position: { line: index + 1, column: line.indexOf(depVersion) + 1 } };
+         dep.version = { value: depVersion.includes('$') ? this.replaceArgsInString(depVersion) : depVersion, position: { line: index + 1, column: line.indexOf(depVersion) + 1 } };
         } else {
             // if version is not specified, generate placeholder template
             if (keyValuePairs) {

--- a/test/providers/build.gradle.test.ts
+++ b/test/providers/build.gradle.test.ts
@@ -186,11 +186,11 @@ dependencies {
         expect(deps).is.eql([
             {
                 name: {value: 'log4j/log4j', position: {line: 0, column: 0}},
-                version: {value: '${versionArg}', position: {line: 30, column: 44}}
+                version: {value: '1.2.3', position: {line: 30, column: 44}}
             },
             {
                 name: {value: 'log4j/log4j', position: {line: 0, column: 0}},
-                version: {value: '${versionArg}', position: {line: 31, column: 66}}
+                version: {value: '1.2.3', position: {line: 31, column: 66}}
             }
         ]);
     });


### PR DESCRIPTION
Bug: Gradle dependency ref was not matched with corresponding dependency line in manifest when line version is set using an argument. 
Fix: argument translated to actual version value to allow matching  