### PR TITLE
feat: support preferring mvnw

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,8 +8,7 @@
 /**
  * Represents the global configuration settings.
  */
-class Config
-{
+class Config {
     stackAnalysisCommand:                           string;
     trackRecommendationAcceptanceCommand:           string;
     telemetryId:                                    string;
@@ -22,6 +21,7 @@ class Config
     usePipDepTree:                                  string;
     vulnerabilityAlertSeverity:                     string;
     exhortMvnPath:                                  string;
+    exhortPreferMvnw:                               string;
     exhortGradlePath:                               string;
     exhortNpmPath:                                  string;
     exhortGoPath:                                   string;
@@ -71,6 +71,7 @@ class Config
         this.usePipDepTree = process.env.VSCEXT_USE_PIP_DEP_TREE || 'false';
         this.vulnerabilityAlertSeverity = process.env.VSCEXT_VULNERABILITY_ALERT_SEVERITY || this.DEFAULT_VULNERABILITY_ALERT_SEVERITY;
         this.exhortMvnPath = process.env.VSCEXT_EXHORT_MVN_PATH || this.DEFAULT_MVN_EXECUTABLE;
+        this.exhortPreferMvnw = process.env.VSCEXT_EXHORT_PREFER_MVNW || 'true';
         this.exhortGradlePath = process.env.VSCEXT_EXHORT_GRADLE_PATH || this.DEFAULT_GRADLE_EXECUTABLE;
         this.exhortNpmPath = process.env.VSCEXT_EXHORT_NPM_PATH || this.DEFAULT_NPM_EXECUTABLE;
         this.exhortGoPath = process.env.VSCEXT_EXHORT_GO_PATH || this.DEFAULT_GO_EXECUTABLE;
@@ -91,7 +92,7 @@ class Config
      * Updates the global configuration with provided data from extension workspace settings.
      * @param data - The data from extension workspace settings to update the global configuration with.
      */
-    updateConfig( rhdaConfig: any ) {
+    updateConfig(rhdaConfig: any) {
         this.matchManifestVersions = rhdaConfig.matchManifestVersions ? 'true' : 'false';
         this.usePythonVirtualEnvironment = rhdaConfig.usePythonVirtualEnvironment ? 'true' : 'false';
         this.useGoMVS = rhdaConfig.useGoMVS ? 'true' : 'false';
@@ -99,6 +100,8 @@ class Config
         this.usePipDepTree = rhdaConfig.usePipDepTree ? 'true' : 'false';
         this.vulnerabilityAlertSeverity = rhdaConfig.vulnerabilityAlertSeverity;
         this.exhortMvnPath = rhdaConfig.mvn.executable.path || this.DEFAULT_MVN_EXECUTABLE;
+        this.exhortPreferMvnw = rhdaConfig.redHatDependencyAnalytics.mvn.preferWrapper === 'fallback' ? 
+            rhdaConfig.fallbacks.useMavenWrapper : (rhdaConfig.redHatDependencyAnalytics.mvn.preferWrapper === 'true');
         this.exhortGradlePath = rhdaConfig.gradle.executable.path || this.DEFAULT_GRADLE_EXECUTABLE;
         this.exhortNpmPath = rhdaConfig.npm.executable.path || this.DEFAULT_NPM_EXECUTABLE;
         this.exhortGoPath = rhdaConfig.go.executable.path || this.DEFAULT_GO_EXECUTABLE;
@@ -119,7 +122,7 @@ class Config
      * Sets the Snyk token.
      * @param token The Snyk token to be set.
      */
-    setExhortSnykToken( token: string ) {
+    setExhortSnykToken(token: string) {
         this.exhortSnykToken = token;
     }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,7 @@ class Config {
 
     private readonly DEFAULT_VULNERABILITY_ALERT_SEVERITY = 'Error';
     private readonly DEFAULT_MVN_EXECUTABLE = 'mvn';
+    private readonly DEFAULT_PREFER_MVNW = 'fallback';
     private readonly DEFAULT_GRADLE_EXECUTABLE = 'gradle';
     private readonly DEFAULT_NPM_EXECUTABLE = 'npm';
     private readonly DEFAULT_GO_EXECUTABLE = 'go';
@@ -100,8 +101,8 @@ class Config {
         this.usePipDepTree = rhdaConfig.usePipDepTree ? 'true' : 'false';
         this.vulnerabilityAlertSeverity = rhdaConfig.vulnerabilityAlertSeverity;
         this.exhortMvnPath = rhdaConfig.mvn.executable.path || this.DEFAULT_MVN_EXECUTABLE;
-        this.exhortPreferMvnw = rhdaConfig.redHatDependencyAnalytics.mvn.preferWrapper === 'fallback' ? 
-            rhdaConfig.fallbacks.useMavenWrapper : (rhdaConfig.redHatDependencyAnalytics.mvn.preferWrapper === 'true');
+        this.exhortPreferMvnw = (rhdaConfig.mvn.preferWrapper || this.DEFAULT_PREFER_MVNW) === 'fallback' ? 
+            (rhdaConfig.fallbacks.useMavenWrapper || 'true') : (rhdaConfig.mvn.preferWrapper === 'true');
         this.exhortGradlePath = rhdaConfig.gradle.executable.path || this.DEFAULT_GRADLE_EXECUTABLE;
         this.exhortNpmPath = rhdaConfig.npm.executable.path || this.DEFAULT_NPM_EXECUTABLE;
         this.exhortGoPath = rhdaConfig.go.executable.path || this.DEFAULT_GO_EXECUTABLE;

--- a/src/dependencyAnalysis/analysis.ts
+++ b/src/dependencyAnalysis/analysis.ts
@@ -163,6 +163,7 @@ async function executeComponentAnalysis(diagnosticFilePath: string, provider: ID
         'EXHORT_PYTHON_INSTALL_BEST_EFFORTS': globalConfig.enablePythonBestEffortsInstallation,
         'EXHORT_PIP_USE_DEP_TREE': globalConfig.usePipDepTree,
         'EXHORT_MVN_PATH': globalConfig.exhortMvnPath,
+        'EXHORT_PREFER_MVNW': globalConfig.exhortPreferMvnw,
         'EXHORT_GRADLE_PATH': globalConfig.exhortGradlePath,
         'EXHORT_NPM_PATH': globalConfig.exhortNpmPath,
         'EXHORT_GO_PATH': globalConfig.exhortGoPath,

--- a/src/server.ts
+++ b/src/server.ts
@@ -92,9 +92,14 @@ connection.onDidCloseTextDocument((params) => {
  */
 connection.onDidChangeConfiguration(() => {
     if (hasConfigurationCapability) {
-        server.conn.workspace.getConfiguration('redHatDependencyAnalytics')
-        .then((rhdaConfig) => {
-            globalConfig.updateConfig(rhdaConfig);
+        server.conn.workspace.getConfiguration([{
+            section: 'redHatDependencyAnalytics'
+        }, {
+            section: 'maven.executable'
+        }]).then(([rhdaConfig, mvn]) => {
+            globalConfig.updateConfig({...rhdaConfig, fallbacks: {
+                useMavenWrapper: mvn !== undefined ? mvn.preferMavenWrapper : true
+            }});
         });
     }
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -23,7 +23,8 @@ describe('Config tests', () => {
         enablePythonBestEffortsInstallation: true,
         usePipDepTree: true,
         mvn: {
-            executable: { path: 'mockPath' }
+            executable: { path: 'mockPath' },
+            preferWrapper: 'fallback'
         },
         gradle: {
             executable: { path: 'mockPath' }
@@ -60,7 +61,10 @@ describe('Config tests', () => {
         },
         podman: {
             executable: { path: 'mockPath' }
-        },   
+        },
+        fallbacks: {
+            useMavenWrapper: 'false'
+        }
     };
 
     const partialRhdaConfig = {
@@ -71,7 +75,8 @@ describe('Config tests', () => {
         enablePythonBestEffortsInstallation: false,
         usePipDepTree: false,
         mvn: {
-            executable: { path: '' }
+            executable: { path: '' },
+            preferWrapper: ''
         },
         gradle: {
             executable: { path: '' }
@@ -109,6 +114,9 @@ describe('Config tests', () => {
         podman: {
             executable: { path: '' }
         },
+        fallbacks: {
+            useMavenWrapper: ''
+        }
     };
 
     it('should initialize with default values when environment variables are not set', () => {
@@ -137,6 +145,7 @@ describe('Config tests', () => {
         expect(mockConfig.exhortDockerPath).to.eq('docker');
         expect(mockConfig.exhortPodmanPath).to.eq('podman');
         expect(mockConfig.exhortImagePlatform).to.eq('');
+        expect(mockConfig.exhortPreferMvnw).to.eq('true')
     });
     
     it('should update configuration based on provided data', () => {
@@ -163,6 +172,7 @@ describe('Config tests', () => {
         expect(mockConfig.exhortDockerPath).to.eq('mockPath');
         expect(mockConfig.exhortPodmanPath).to.eq('mockPath');
         expect(mockConfig.exhortImagePlatform).to.eq('mockPlatform');
+        expect(mockConfig.exhortPreferMvnw).to.eq('false')
     });
 
     it('should update configuration based on provided partial data', () => {
@@ -189,6 +199,7 @@ describe('Config tests', () => {
         expect(mockConfig.exhortDockerPath).to.eq('docker');
         expect(mockConfig.exhortPodmanPath).to.eq('podman');
         expect(mockConfig.exhortImagePlatform).to.eq('');
+        expect(mockConfig.exhortPreferMvnw).to.eq('true')
     });
 
     it('should set Exhort Snyk Token', () => {


### PR DESCRIPTION
LSP-side of https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/757. Must duplicate a tiny bit of logic in deriving the exhort config value due to the LSP server receiving configuration both in the initial environment variables (set by the logic on the editors' side) and receiving the raw configuration as well per the protocol (where we need to duplicate the aforementioned logic)

Depends on https://github.com/trustification/exhort-javascript-api/pull/170