### PR TITLE
chore: upgrade exhort-javsacript-api version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     
     - name: Create .npmrc
       run: |
-        echo "@RHEcosystemAppEng:registry=https://npm.pkg.github.com" >> ~/.npmrc
+        echo "@trustification:registry=https://npm.pkg.github.com" >> ~/.npmrc
 
     - name: Install project modules
       run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Create .npmrc
         run: |
-          echo "@RHEcosystemAppEng:registry=https://npm.pkg.github.com" >> ~/.npmrc
+          echo "@trustification:registry=https://npm.pkg.github.com" >> ~/.npmrc
       
       - name: Configure git
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.9.4-ea.26",
       "license": "Apache-2.0",
       "dependencies": {
-        "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.50",
+        "@trustification/exhort-javascript-api": "^0.1.1-ea.54",
         "@xml-tools/ast": "^5.0.5",
         "@xml-tools/parser": "^1.0.11",
         "json-to-ast": "^2.1.0",
@@ -763,28 +763,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/@RHEcosystemAppEng/exhort-javascript-api": {
-      "version": "0.1.1-ea.50",
-      "resolved": "https://npm.pkg.github.com/download/@RHEcosystemAppEng/exhort-javascript-api/0.1.1-ea.50/5e588f2e92c3d1e8a232333c708ed3f1ba9e2545",
-      "integrity": "sha512-vosnUYxVg4VMASkt20DK0EmBpDWV0gY49lM+CB2AiQxL/8RcC4bTsLqxe3Dd/tPXv3Dir6vlGFBGfbF3vwgMjw==",
-      "dependencies": {
-        "@babel/core": "^7.23.2",
-        "@cyclonedx/cyclonedx-library": "~1.13.3",
-        "fast-toml": "^0.5.4",
-        "fast-xml-parser": "^4.2.4",
-        "help": "^3.0.2",
-        "node-fetch": "^2.6.7",
-        "packageurl-js": "^1.0.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "exhort-javascript-api": "dist/src/cli.js"
-      },
-      "engines": {
-        "node": ">= 18.0.0",
-        "npm": ">= 9.0.0"
-      }
-    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -828,6 +806,29 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "node_modules/@trustification/exhort-javascript-api": {
+      "version": "0.1.1-ea.54",
+      "resolved": "https://npm.pkg.github.com/download/@trustification/exhort-javascript-api/0.1.1-ea.54/aae647f54b19514204c3dd98d554ae4513350d4e",
+      "integrity": "sha512-rep69WMzo7s8PUxuPCgnExe3cvBFxpGj1qMpBGzpUcbzBuLsDTr2YbbExpALzhtsnO05LfowInp1FERTEeX8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "^7.23.2",
+        "@cyclonedx/cyclonedx-library": "~1.13.3",
+        "fast-toml": "^0.5.4",
+        "fast-xml-parser": "^4.2.4",
+        "help": "^3.0.2",
+        "node-fetch": "^2.6.7",
+        "packageurl-js": "^1.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "exhort-javascript-api": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">= 18.0.0",
+        "npm": ">= 9.0.0"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -2235,20 +2236,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "dependencies": {
-    "@RHEcosystemAppEng/exhort-javascript-api": "^0.1.1-ea.50",
+    "@trustification/exhort-javascript-api": "^0.1.1-ea.54",
     "@xml-tools/ast": "^5.0.5",
     "@xml-tools/parser": "^1.0.11",
     "json-to-ast": "^2.1.0",

--- a/src/dependencyAnalysis/analysis.ts
+++ b/src/dependencyAnalysis/analysis.ts
@@ -4,8 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import * as path from 'path';
-import exhort from '@RHEcosystemAppEng/exhort-javascript-api';
+import exhort from '@trustification/exhort-javascript-api';
 
 import { connection } from '../server';
 import { globalConfig } from '../config';
@@ -149,11 +148,10 @@ class AnalysisResponse implements IAnalysisResponse {
 /**
  * Performs RHDA component analysis on provided manifest contents/path and fileType based on ecosystem.
  * @param diagnosticFilePath - The path to the manifest file to analyze.
- * @param contents - The contents of the manifest file to analyze.
  * @param provider - The dependency provider of the corresponding ecosystem.
  * @returns A Promise resolving to an AnalysisResponse object.
  */
-async function executeComponentAnalysis (diagnosticFilePath: string, contents: string, provider: IDependencyProvider): Promise<AnalysisResponse> {
+async function executeComponentAnalysis(diagnosticFilePath: string, provider: IDependencyProvider): Promise<AnalysisResponse> {
     
     // Define configuration options for the component analysis request
     const options = {
@@ -177,7 +175,8 @@ async function executeComponentAnalysis (diagnosticFilePath: string, contents: s
         options['EXHORT_SNYK_TOKEN'] = globalConfig.exhortSnykToken;
     }
 
-    const componentAnalysisJson = await exhort.componentAnalysis(path.basename(diagnosticFilePath), contents, options, decodeUriPath(diagnosticFilePath)); // Execute component analysis
+    // Execute component analysis
+    const componentAnalysisJson = await exhort.componentAnalysis(decodeUriPath(diagnosticFilePath), options);
 
     return new AnalysisResponse(componentAnalysisJson, diagnosticFilePath, provider);
 }

--- a/src/dependencyAnalysis/diagnostics.ts
+++ b/src/dependencyAnalysis/diagnostics.ts
@@ -50,24 +50,24 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
                     ref,
                     dependencyData,
                 );
-                
+
                 const vulnerabilityDiagnostic = vulnerability.getDiagnostic();
                 this.diagnostics.push(vulnerabilityDiagnostic);
 
                 const loc = vulnerabilityDiagnostic.range.start.line + '|' + vulnerabilityDiagnostic.range.start.character;
 
                 dependencyData.forEach(dd => {
-    
+
                     const actionRef = vulnerabilityDiagnostic.severity < 3 ? dd.remediationRef : dd.recommendationRef;
 
                     if (actionRef) {
                         this.createCodeAction(loc, actionRef, dependency.context, dd.sourceId, vulnerabilityDiagnostic);
                     }
-    
+
                     const vulnProvider = dd.sourceId.split('(')[0];
                     const issuesCount = dd.issuesCount;
                     this.vulnCount[vulnProvider] = (this.vulnCount[vulnProvider] || 0) + issuesCount;
-                });      
+                });
             }
             connection.sendDiagnostics({ uri: this.diagnosticFilePath, diagnostics: this.diagnostics });
         });
@@ -100,7 +100,7 @@ class DiagnosticsPipeline extends AbstractDiagnosticsPipeline<DependencyData> {
  * @returns A Promise that resolves when diagnostics are completed.
  */
 async function performDiagnostics(diagnosticFilePath: string, contents: string, provider: IDependencyProvider) {
-    try {        
+    try {
         const dependencies = await provider.collect(contents);
         const ecosystem = provider.getEcosystem();
         const dependencyMap = new DependencyMap(dependencies, ecosystem);
@@ -108,7 +108,7 @@ async function performDiagnostics(diagnosticFilePath: string, contents: string, 
         const diagnosticsPipeline = new DiagnosticsPipeline(dependencyMap, diagnosticFilePath);
         diagnosticsPipeline.clearDiagnostics();
 
-        const response = await executeComponentAnalysis(diagnosticFilePath, contents, provider);
+        const response = await executeComponentAnalysis(diagnosticFilePath, provider);
 
         clearCodeActionsMap(diagnosticFilePath);
 


### PR DESCRIPTION
Required by https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/pull/757 and https://github.com/fabric8-analytics/fabric8-analytics-lsp-server/pull/264. Primarily includes the changes from https://github.com/trustification/exhort-javascript-api/releases/tag/v0.1.1-ea.52